### PR TITLE
SLING-7357: set content type to forward distrib http headers

### DIFF
--- a/src/main/java/org/apache/sling/distribution/agent/impl/ForwardDistributionAgentFactory.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/ForwardDistributionAgentFactory.java
@@ -34,6 +34,7 @@ import org.apache.felix.scr.annotations.PropertyOption;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferenceCardinality;
 import org.apache.felix.scr.annotations.ReferencePolicy;
+import org.apache.http.HttpHeaders;
 import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.osgi.PropertiesUtil;
@@ -246,8 +247,10 @@ public class ForwardDistributionAgentFactory extends AbstractDistributionAgentFa
         Map<String, String> priorityQueues = PropertiesUtil.toMap(config.get(PRIORITY_QUEUES), new String[0]);
         priorityQueues = SettingsUtils.removeEmptyEntries(priorityQueues);
 
+        Map<String, String> headers = new HashMap<String, String>(1);
+        headers.put(HttpHeaders.CONTENT_TYPE, packageBuilder.getContentType());
         Integer timeout = PropertiesUtil.toInteger(HTTP, 10) * 1000;
-        HttpConfiguration httpConfiguration = new HttpConfiguration(timeout);
+        HttpConfiguration httpConfiguration = new HttpConfiguration(timeout, headers);
 
         DistributionPackageExporter packageExporter = new LocalDistributionPackageExporter(packageBuilder);
 

--- a/src/main/java/org/apache/sling/distribution/monitor/impl/MonitoringDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/monitor/impl/MonitoringDistributionPackageBuilder.java
@@ -59,6 +59,11 @@ public final class MonitoringDistributionPackageBuilder implements DistributionP
         return wrapped.getType();
     }
 
+    @Override
+    public String getContentType() {
+        return wrapped.getContentType();
+    }
+
     @Nonnull
     @Override
     public DistributionPackage createPackage(@Nonnull ResourceResolver resourceResolver, @Nonnull DistributionRequest request) throws DistributionException {

--- a/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageBuilder.java
@@ -40,6 +40,12 @@ public interface DistributionPackageBuilder {
     String getType();
 
     /**
+     * returns the content type of packages created and consumed by the package builder.
+     * @return the content type of the package
+     */
+    String getContentType();
+
+    /**
      * creates a {@link DistributionPackage} for a specific {@link org.apache.sling.distribution.DistributionRequest}
      *
      * @param resourceResolver the resource resolver used to access the resources to be packaged

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/AbstractDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/AbstractDistributionPackageBuilder.java
@@ -50,13 +50,19 @@ public abstract class AbstractDistributionPackageBuilder implements Distribution
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final String type;
+    private final String contentType;
 
-    AbstractDistributionPackageBuilder(String type) {
+    AbstractDistributionPackageBuilder(String type, String contentType) {
         this.type = type;
+        this.contentType = contentType;
     }
 
     public String getType() {
         return type;
+    }
+
+    public String getContentType() {
+        return this.contentType;
     }
 
     @Nonnull

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
@@ -66,7 +66,7 @@ public class FileDistributionPackageBuilder extends AbstractDistributionPackageB
                                           String tempFilesFolder,
                                           String digestAlgorithm, String[] nodeFilters,
                                           String[] propertyFilters) {
-        super(type);
+        super(type, distributionContentSerializer.getContentType());
         this.distributionContentSerializer = distributionContentSerializer;
         this.nodeFilters = VltUtils.parseFilters(nodeFilters);
         this.propertyFilters = VltUtils.parseFilters(propertyFilters);

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
@@ -77,7 +77,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
                                               boolean useOffHeapMemory,
                                               String digestAlgorithm, String[] nodeFilters,
                                               String[] propertyFilters) {
-        super(type);
+        super(type, distributionContentSerializer.getContentType());
         this.distributionContentSerializer = distributionContentSerializer;
         this.nodeFilters = VltUtils.parseFilters(nodeFilters);
         this.propertyFilters = VltUtils.parseFilters(propertyFilters);

--- a/src/main/java/org/apache/sling/distribution/serialization/DistributionContentSerializer.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/DistributionContentSerializer.java
@@ -56,6 +56,12 @@ public interface DistributionContentSerializer {
     String getName();
 
     /**
+     * retrieve the mime type of the exported content of this content serializer
+     * @implNote the default implementation returns application/octet-stream.
+     */
+    String getContentType();
+
+    /**
      * whether or not this {@link DistributionContentSerializer} can build package filters for including / excluding
      * certain resources / attributes directly from a {@link org.apache.sling.distribution.DistributionRequest}
      * @return {@code true} if it can build filters from a request, {@code false} otherwise

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
@@ -237,6 +237,10 @@ public class DistributionPackageBuilderFactory implements DistributionPackageBui
         return packageBuilder.getType();
     }
 
+    public String getContentType() {
+        return contentSerializer.getContentType();
+    }
+
     @Nonnull
     public DistributionPackage createPackage(@Nonnull ResourceResolver resourceResolver, @Nonnull DistributionRequest request) throws DistributionException {
         return packageBuilder.createPackage(resourceResolver, request);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
@@ -197,6 +197,11 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
     }
 
     @Override
+    public String getContentType() {
+        return "application/octet-stream";
+    }
+
+    @Override
     public boolean isRequestFiltering() {
         return true;
     }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -288,6 +288,10 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
         return packageBuilder.getType();
     }
 
+    public String getContentType() {
+        return packageBuilder.getContentType();
+    }
+
     @Nonnull
     public DistributionPackage createPackage(@Nonnull ResourceResolver resourceResolver, @Nonnull DistributionRequest request) throws DistributionException {
         return packageBuilder.createPackage(resourceResolver, request);

--- a/src/main/java/org/apache/sling/distribution/serialization/package-info.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/package-info.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@Version("0.1.0")
+@Version("1.0.0")
 package org.apache.sling.distribution.serialization;
 
 import aQute.bnd.annotation.Version;

--- a/src/main/java/org/apache/sling/distribution/transport/impl/HttpConfiguration.java
+++ b/src/main/java/org/apache/sling/distribution/transport/impl/HttpConfiguration.java
@@ -18,6 +18,9 @@
  */
 package org.apache.sling.distribution.transport.impl;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * HTTP related configuration for {@link SimpleHttpDistributionTransport}
  */
@@ -25,15 +28,24 @@ public class HttpConfiguration {
 
     private final Integer connectTimeout;
     private final Integer socketTimeout;
+    private final Map<String, String> headers;
 
     public HttpConfiguration(Integer timeout) {
-        this.socketTimeout = timeout;
-        this.connectTimeout = timeout;
+        this(timeout, timeout);
     }
 
     public HttpConfiguration(Integer connectTimeout, Integer socketTimeout) {
+        this(connectTimeout, socketTimeout, Collections.<String, String>emptyMap());
+    }
+
+    public HttpConfiguration(Integer timeout, Map<String, String> headers) {
+        this(timeout, timeout, headers);
+    }
+
+    public HttpConfiguration(Integer connectTimeout, Integer socketTimeout, Map<String, String> headers) {
         this.connectTimeout = connectTimeout;
         this.socketTimeout = socketTimeout;
+        this.headers = headers;
     }
 
     public Integer getConnectTimeout() {
@@ -42,5 +54,9 @@ public class HttpConfiguration {
 
     public Integer getSocketTimeout() {
         return socketTimeout;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
     }
 }

--- a/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
+++ b/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
@@ -137,6 +137,10 @@ public class SimpleHttpDistributionTransport implements DistributionTransport {
                     }
                 }
 
+                for (Map.Entry<String, String> header : httpConfiguration.getHeaders().entrySet()) {
+                    req.addHeader(header.getKey(), header.getValue());
+                }
+
                 InputStream inputStream = null;
                 try {
                     inputStream = DistributionPackageUtils.createStreamWithHeader(distributionPackage);


### PR DESCRIPTION
Added content type to be specified by the DistributionContentSerializer and DistributionPackageBuilder. 

This is a major change of org.apache.sling.distribution.serialization. 