### PR TITLE
SLING-7382: move content-type logic to DistributionPackage and DistributionPackageInfo

### DIFF
--- a/src/main/java/org/apache/sling/distribution/agent/impl/ForwardDistributionAgentFactory.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/ForwardDistributionAgentFactory.java
@@ -247,10 +247,8 @@ public class ForwardDistributionAgentFactory extends AbstractDistributionAgentFa
         Map<String, String> priorityQueues = PropertiesUtil.toMap(config.get(PRIORITY_QUEUES), new String[0]);
         priorityQueues = SettingsUtils.removeEmptyEntries(priorityQueues);
 
-        Map<String, String> headers = new HashMap<String, String>(1);
-        headers.put(HttpHeaders.CONTENT_TYPE, packageBuilder.getContentType());
         Integer timeout = PropertiesUtil.toInteger(HTTP, 10) * 1000;
-        HttpConfiguration httpConfiguration = new HttpConfiguration(timeout, headers);
+        HttpConfiguration httpConfiguration = new HttpConfiguration(timeout);
 
         DistributionPackageExporter packageExporter = new LocalDistributionPackageExporter(packageBuilder);
 

--- a/src/main/java/org/apache/sling/distribution/packaging/DistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/DistributionPackage.java
@@ -47,6 +47,15 @@ public interface DistributionPackage {
     String getType();
 
     /**
+     * get the content type of the package. This is the mime-type of the content returned by {@link DistributionPackage#createInputStream()}
+     * including optional parameters like the charset.
+     *
+     * @return the content type as mime-type
+     */
+    @Nonnull
+    String getContentType();
+
+    /**
      * creates a package stream.
      * a new stream is created for each call and it is the caller's obligation to close the stream.
      *

--- a/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageInfo.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageInfo.java
@@ -42,6 +42,11 @@ public final class DistributionPackageInfo extends ValueMapDecorator implements 
     public static final String PROPERTY_PACKAGE_TYPE = "package.type";
 
     /**
+     * distribution package type
+     */
+    public static final String PROPERTY_CONTENT_TYPE = "content.type";
+
+    /**
      * distribution request paths
      */
     public static final String PROPERTY_REQUEST_PATHS = "request.paths";
@@ -85,6 +90,11 @@ public final class DistributionPackageInfo extends ValueMapDecorator implements 
     @Nonnull
     public String getType() {
         return get(PROPERTY_PACKAGE_TYPE, String.class);
+    }
+
+    @Nonnull
+    public String getContentType() {
+        return get(PROPERTY_CONTENT_TYPE, "application/octet-stream");
     }
 
     /**

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/AbstractDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/AbstractDistributionPackage.java
@@ -36,11 +36,13 @@ public abstract class AbstractDistributionPackage implements SharedDistributionP
     private final String digestAlgorithm;
     private final String digestMessage;
 
-    AbstractDistributionPackage(String id, String type, String digestAlgorithm, String digestMessage) {
+    AbstractDistributionPackage(String id, String type, String contentType, String digestAlgorithm, String digestMessage) {
         this.id = id;
         this.info = new DistributionPackageInfo(type);
         this.digestAlgorithm = digestAlgorithm;
         this.digestMessage = digestMessage;
+
+        this.info.put(DistributionPackageInfo.PROPERTY_CONTENT_TYPE, contentType);
     }
 
     @Nonnull
@@ -56,6 +58,11 @@ public abstract class AbstractDistributionPackage implements SharedDistributionP
     @Nonnull
     public String getType() {
         return info.getType();
+    }
+
+    @Override
+    public String getContentType() {
+        return info.getContentType();
     }
 
     @Nullable

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/DistributionPackageWrapper.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/DistributionPackageWrapper.java
@@ -50,6 +50,11 @@ public class DistributionPackageWrapper implements DistributionPackage {
         return wrappedPackage.getType();
     }
 
+    @Override
+    public String getContentType() {
+        return wrappedPackage.getContentType();
+    }
+
     @Nonnull
     public InputStream createInputStream() throws IOException {
         return wrappedPackage.createInputStream();

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackage.java
@@ -43,9 +43,10 @@ public class FileDistributionPackage extends AbstractDistributionPackage {
 
     public FileDistributionPackage(@Nonnull File file,
                                    @Nonnull String type,
+                                   @Nonnull String contentType,
                                    @Nullable String digestAlgorithm,
                                    @Nullable String digestMessage) {
-        super(file.getName(), type, digestAlgorithm, digestMessage);
+        super(file.getName(), type, contentType, digestAlgorithm, digestMessage);
         this.file = file;
 
         this.getInfo().put(DistributionPackageInfo.PROPERTY_REQUEST_TYPE, DistributionRequestType.ADD);

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
@@ -105,7 +105,7 @@ public class FileDistributionPackageBuilder extends AbstractDistributionPackageB
             if (digestAlgorithm != null) {
                 digestMessage = readDigestMessage((DigestOutputStream) outputStream);
             }
-            distributionPackage = new FileDistributionPackage(file, getType(), digestAlgorithm, digestMessage);
+            distributionPackage = new FileDistributionPackage(file, getType(), distributionContentSerializer.getContentType(), digestAlgorithm, digestMessage);
         } catch (IOException e) {
             throw new DistributionException(e);
         } finally {
@@ -141,7 +141,7 @@ public class FileDistributionPackageBuilder extends AbstractDistributionPackageB
             outputStream.flush();
 
             String digestMessage = readDigestMessage(outputStream);
-            distributionPackage = new FileDistributionPackage(file, getType(), digestAlgorithm, digestMessage);
+            distributionPackage = new FileDistributionPackage(file, getType(), distributionContentSerializer.getContentType(), digestAlgorithm, digestMessage);
         } catch (Exception e) {
             throw new DistributionException(e);
         } finally {
@@ -164,6 +164,6 @@ public class FileDistributionPackageBuilder extends AbstractDistributionPackageB
 
     @Override
     protected DistributionPackage getPackageInternal(@Nonnull ResourceResolver resourceResolver, @Nonnull String id) {
-        return new FileDistributionPackage(new File(tempDirectory, id), getType(), null, null);
+        return new FileDistributionPackage(new File(tempDirectory, id), getType(), distributionContentSerializer.getContentType(), null, null);
     }
 }

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ReferencePackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ReferencePackage.java
@@ -38,7 +38,7 @@ public class ReferencePackage extends AbstractDistributionPackage {
     private final String reference;
 
     public ReferencePackage(DistributionPackage distributionPackage) {
-        super(REFERENCE_PREFIX + distributionPackage.getId(), distributionPackage.getType(), null, null);
+        super(REFERENCE_PREFIX + distributionPackage.getId(), distributionPackage.getType(), distributionPackage.getContentType(),null, null);
         this.distributionPackage = distributionPackage;
         this.reference = REFERENCE_PREFIX + distributionPackage.getId();
         getInfo().putAll(distributionPackage.getInfo());

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ReferencePackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ReferencePackage.java
@@ -38,7 +38,7 @@ public class ReferencePackage extends AbstractDistributionPackage {
     private final String reference;
 
     public ReferencePackage(DistributionPackage distributionPackage) {
-        super(REFERENCE_PREFIX + distributionPackage.getId(), distributionPackage.getType(), distributionPackage.getContentType(),null, null);
+        super(REFERENCE_PREFIX + distributionPackage.getId(), "text/plain; charset=UTF-8", distributionPackage.getContentType(),null, null);
         this.distributionPackage = distributionPackage;
         this.reference = REFERENCE_PREFIX + distributionPackage.getId();
         getInfo().putAll(distributionPackage.getInfo());
@@ -62,7 +62,7 @@ public class ReferencePackage extends AbstractDistributionPackage {
     @Nonnull
     @Override
     public InputStream createInputStream() throws IOException {
-        return new ByteArrayInputStream(reference.getBytes());
+        return new ByteArrayInputStream(reference.getBytes("UTF-8"));
     }
 
     @Override

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackage.java
@@ -48,10 +48,11 @@ public class ResourceDistributionPackage extends AbstractDistributionPackage {
 
     ResourceDistributionPackage(Resource resource,
                                 String type,
+                                String contentType,
                                 ResourceResolver resourceResolver,
                                 @Nullable String digestAlgorithm,
                                 @Nullable String digestMessage) {
-        super(resource.getName(), type, digestAlgorithm, digestMessage);
+        super(resource.getName(), type, contentType, digestAlgorithm, digestMessage);
         this.resourceResolver = resourceResolver;
         ValueMap valueMap = resource.getValueMap();
         assert type.equals(valueMap.get("type")) : "wrong resource type";

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
@@ -130,7 +130,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
                 outputStream.clean();
             }
 
-            distributionPackage = new ResourceDistributionPackage(packageResource, getType(), resourceResolver, digestAlgorithm, digestMessage);
+            distributionPackage = new ResourceDistributionPackage(packageResource, getType(), distributionContentSerializer.getContentType(), resourceResolver, digestAlgorithm, digestMessage);
         } catch (IOException e) {
             throw new DistributionException(e);
         }
@@ -151,7 +151,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
             Resource packagesRoot = DistributionPackageUtils.getPackagesRoot(resourceResolver, packagesPath);
 
             Resource packageResource = uploadStream(resourceResolver, packagesRoot, inputStream, -1);
-            return new ResourceDistributionPackage(packageResource, getType(), resourceResolver, null, null);
+            return new ResourceDistributionPackage(packageResource, getType(), distributionContentSerializer.getContentType(), resourceResolver, null, null);
         } catch (PersistenceException e) {
             throw new DistributionException(e);
         }
@@ -176,7 +176,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
             if (packageResource == null) {
                 return null;
             } else {
-                return new ResourceDistributionPackage(packageResource, getType(), resourceResolver, null, null);
+                return new ResourceDistributionPackage(packageResource, getType(), distributionContentSerializer.getContentType(), resourceResolver, null, null);
             }
         } catch (PersistenceException e) {
             return null;
@@ -243,7 +243,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
             throws DistributionException {
         try {
             Resource packagesRoot = DistributionPackageUtils.getPackagesRoot(resourceResolver, packagesPath);
-            return new ResourceDistributionPackageIterator(packagesRoot, resourceResolver, getType());
+            return new ResourceDistributionPackageIterator(packagesRoot, resourceResolver, getType(), distributionContentSerializer.getContentType());
         } catch (PersistenceException e) {
             throw new DistributionException("Failed to get the package list", e);
         }
@@ -256,12 +256,14 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
         final ResourceResolver resourceResolver;
 
         final String type;
+        final String contentType;
 
         private ResourceDistributionPackageIterator(@Nonnull Resource packagesRoot, @Nonnull ResourceResolver resourceResolver,
-                                            @Nonnull String type) {
+                                            @Nonnull String type, @Nonnull String contentType) {
             this.packages = packagesRoot.listChildren();
             this.resourceResolver = resourceResolver;
             this.type = type;
+            this.contentType = contentType;
         }
 
         @Override
@@ -272,7 +274,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
         @Override
         public ResourceDistributionPackage next() {
             Resource packageResource = packages.next();
-            return new ResourceDistributionPackage(packageResource, type, resourceResolver, null, null);
+            return new ResourceDistributionPackage(packageResource, type, contentType, resourceResolver, null, null);
         }
 
         @Override

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackage.java
@@ -45,7 +45,7 @@ public class SimpleDistributionPackage extends AbstractDistributionPackage imple
     private final long size;
 
     public SimpleDistributionPackage(DistributionRequest request, String type) {
-        super(toIdString(request), type, null, null);
+        super(toIdString(request), type, "text/plain; charset=UTF-8",null, null);
         String[] paths = request.getPaths();
         DistributionRequestType requestType = request.getRequestType();
 

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/exporter/RemoteDistributionPackageExporter.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/exporter/RemoteDistributionPackageExporter.java
@@ -27,6 +27,7 @@ import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.DistributionRequestType;
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.log.impl.DefaultDistributionLog;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.packaging.DistributionPackageProcessor;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageUtils;
 import org.apache.sling.distribution.packaging.DistributionPackage;
@@ -67,6 +68,8 @@ public class RemoteDistributionPackageExporter implements DistributionPackageExp
                         packageBuilder, secretProvider, httpConfiguration));
             }
         }
+
+        this.distributionContext.put(DistributionPackageInfo.PROPERTY_CONTENT_TYPE, packageBuilder.getContentType());
     }
 
     public void exportPackages(@Nonnull ResourceResolver resourceResolver, @Nonnull DistributionRequest distributionRequest, @Nonnull DistributionPackageProcessor packageProcessor) throws DistributionException {

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageExporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageExporterServlet.java
@@ -87,8 +87,6 @@ public class DistributionPackageExporterServlet extends SlingAllMethodsServlet {
 
         final long start = System.currentTimeMillis();
 
-        response.setContentType(ContentType.APPLICATION_OCTET_STREAM.toString());
-
         DistributionRequest distributionRequest = RequestUtils.fromServletRequest(request);
         ResourceResolver resourceResolver = request.getResourceResolver();
 
@@ -104,7 +102,7 @@ public class DistributionPackageExporterServlet extends SlingAllMethodsServlet {
                     int bytesCopied = -1;
                     try {
                         inputStream = DistributionPackageUtils.createStreamWithHeader(distributionPackage);
-
+                        response.setContentType(distributionPackage.getContentType());
                         bytesCopied = IOUtils.copy(inputStream, response.getOutputStream());
                     } catch (IOException e) {
                         log.error("cannot process package", e);

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageExporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageExporterServlet.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
-import org.apache.http.entity.ContentType;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ResourceResolver;

--- a/src/main/java/org/apache/sling/distribution/transport/impl/HttpTransportUtils.java
+++ b/src/main/java/org/apache/sling/distribution/transport/impl/HttpTransportUtils.java
@@ -19,21 +19,25 @@
 
 package org.apache.sling.distribution.transport.impl;
 
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.protocol.HTTP;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 class HttpTransportUtils {
 
-    public static InputStream fetchNextPackage(Executor executor, URI distributionURI, HttpConfiguration httpConfiguration)
+    public static InputStream fetchNextPackage(Executor executor, URI distributionURI, HttpConfiguration httpConfiguration, Map<String, Object> info)
             throws URISyntaxException, IOException {
         URI fetchUri = getFetchUri(distributionURI);
         Request fetchReq = Request.Post(fetchUri)
@@ -48,6 +52,11 @@ class HttpTransportUtils {
         }
 
         HttpEntity entity = httpResponse.getEntity();
+
+        ContentType contentType = ContentType.get(entity);
+        if (contentType != null) {
+            info.put(DistributionPackageInfo.PROPERTY_CONTENT_TYPE, contentType.toString());
+        }
 
         return entity.getContent();
     }

--- a/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
+++ b/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
+import org.apache.http.ParseException;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
@@ -177,11 +178,19 @@ public class SimpleHttpDistributionTransport implements DistributionTransport {
 
         try {
             URI distributionURI = RequestUtils.appendDistributionRequest(distributionEndpoint.getUri(), distributionRequest);
-
+            String contentTypeProperty = distributionContext.get(DistributionPackageInfo.PROPERTY_CONTENT_TYPE, String.class);
+            ContentType contentType = null;
+            if (contentTypeProperty != null) {
+                try {
+                    contentType = ContentType.parse(contentTypeProperty);
+                } catch (ParseException e) {
+                    log.info("Couldn't parse expected content type of DistributionRequest.", e);
+                }
+            }
             Executor executor = getExecutor(distributionContext);
             Map<String, Object> info = new HashMap<String, Object>();
             // TODO : add queue parameter
-            InputStream inputStream = HttpTransportUtils.fetchNextPackage(executor, distributionURI, httpConfiguration, info);
+            InputStream inputStream = HttpTransportUtils.fetchNextPackage(executor, distributionURI, httpConfiguration, contentType, info);
 
             if (inputStream == null) {
                 return null;

--- a/src/test/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransportTest.java
+++ b/src/test/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransportTest.java
@@ -73,7 +73,9 @@ public class SimpleHttpDistributionTransportTest {
                 endpoint, packageBuilder, secretProvider, new HttpConfiguration(1000, 1000));
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
         DistributionPackage distributionPackage = mock(DistributionPackage.class);
-        when(distributionPackage.getInfo()).thenReturn(new DistributionPackageInfo("type"));
+        DistributionPackageInfo info = new DistributionPackageInfo("type");
+        when(distributionPackage.getInfo()).thenReturn(info);
+        when(distributionPackage.getContentType()).thenReturn(info.getContentType());
         InputStream stream = mock(InputStream.class);
         when(distributionPackage.createInputStream()).thenReturn(stream);
         DistributionTransportContext distributionContext = mock(DistributionTransportContext.class);


### PR DESCRIPTION
Moving the logic for the content-type to DistributionPackage/DistributionPackageInfo ensures that for both producer and consumer side the contentType is set and the implementation can rely on it. On the other hand no further verification is implemented yet. 