### PR TITLE
SLING-7364: optionally omit package metadata header

### DIFF
--- a/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageInfo.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageInfo.java
@@ -57,6 +57,9 @@ public final class DistributionPackageInfo extends ValueMapDecorator implements 
      */
     public static final String PROPERTY_REQUEST_TYPE = "request.type";
 
+    public static final String PROPERTY_REFERENCE_REQUIRED = "reference-required";
+
+    public final static String PROPERTY_REMOTE_PACKAGE_ID = "remote.package.id";
 
     /**
      * Creates a new wrapper around a given map.

--- a/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageInfo.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageInfo.java
@@ -59,7 +59,9 @@ public final class DistributionPackageInfo extends ValueMapDecorator implements 
 
     public static final String PROPERTY_REFERENCE_REQUIRED = "reference-required";
 
-    public final static String PROPERTY_REMOTE_PACKAGE_ID = "remote.package.id";
+    public static final String PROPERTY_REMOTE_PACKAGE_ID = "remote.package.id";
+
+    public static final String PROPERTY_HEADER_REQUIRED = "header-required";
 
     /**
      * Creates a new wrapper around a given map.

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/AbstractDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/AbstractDistributionPackageBuilder.java
@@ -52,11 +52,13 @@ public abstract class AbstractDistributionPackageBuilder implements Distribution
     private final String type;
     private final String contentType;
     private final boolean serializerSupportsDeletion;
+    private final boolean includeHeader;
 
-    AbstractDistributionPackageBuilder(String type, String contentType, boolean serializerSupportsDeletion) {
+    AbstractDistributionPackageBuilder(String type, String contentType, boolean serializerSupportsDeletion, boolean includeHeader) {
         this.type = type;
         this.contentType = contentType;
         this.serializerSupportsDeletion = serializerSupportsDeletion;
+        this.includeHeader = includeHeader;
     }
 
     public String getType() {
@@ -90,7 +92,7 @@ public abstract class AbstractDistributionPackageBuilder implements Distribution
             throw new DistributionException("unknown action type " + request.getRequestType());
         }
 
-        DistributionPackageUtils.fillInfo(distributionPackage.getInfo(), request);
+        DistributionPackageUtils.fillInfo(distributionPackage.getInfo(), request, includeHeader);
 
         return distributionPackage;
     }

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/DistributionPackageUtils.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/DistributionPackageUtils.java
@@ -72,8 +72,6 @@ public class DistributionPackageUtils {
     private static final Object repolock = new Object();
     private static final Object filelock = new Object();
 
-    public final static String PROPERTY_REMOTE_PACKAGE_ID = "remote.package.id";
-
     /**
      * distribution package origin queue
      */
@@ -213,10 +211,11 @@ public class DistributionPackageUtils {
         Map<String, Object> headerInfo = new HashMap<String, Object>();
         headerInfo.put(DistributionPackageInfo.PROPERTY_REQUEST_TYPE, packageInfo.getRequestType());
         headerInfo.put(DistributionPackageInfo.PROPERTY_REQUEST_PATHS, packageInfo.getPaths());
-        headerInfo.put(PROPERTY_REMOTE_PACKAGE_ID, distributionPackage.getId());
-        if (packageInfo.containsKey("reference-required")) {
-            headerInfo.put("reference-required", packageInfo.get("reference-required"));
-            log.info("setting reference-required to {}", packageInfo.get("reference-required"));
+        headerInfo.put(DistributionPackageInfo.PROPERTY_REMOTE_PACKAGE_ID, distributionPackage.getId());
+        if (packageInfo.containsKey(DistributionPackageInfo.PROPERTY_REFERENCE_REQUIRED)) {
+            Object refRequired = packageInfo.get(DistributionPackageInfo.PROPERTY_REFERENCE_REQUIRED);
+            headerInfo.put(DistributionPackageInfo.PROPERTY_REFERENCE_REQUIRED, refRequired);
+            log.info("setting reference-required to {}", refRequired);
         }
         writeInfo(outputStream, headerInfo);
 

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
@@ -66,8 +66,8 @@ public class FileDistributionPackageBuilder extends AbstractDistributionPackageB
                                           DistributionContentSerializer distributionContentSerializer,
                                           String tempFilesFolder,
                                           String digestAlgorithm, String[] nodeFilters,
-                                          String[] propertyFilters) {
-        super(type, distributionContentSerializer.getContentType(), distributionContentSerializer.isDeletionSupported());
+                                          String[] propertyFilters, boolean includeHeader) {
+        super(type, distributionContentSerializer.getContentType(), distributionContentSerializer.isDeletionSupported(), includeHeader);
         this.distributionContentSerializer = distributionContentSerializer;
         this.nodeFilters = VltUtils.parseFilters(nodeFilters);
         this.propertyFilters = VltUtils.parseFilters(propertyFilters);

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilder.java
@@ -39,6 +39,7 @@ import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.packaging.DistributionPackage;
 import org.apache.sling.distribution.packaging.DistributionPackageBuilder;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.serialization.DistributionContentSerializer;
 import org.apache.sling.distribution.serialization.DistributionExportFilter;
 import org.apache.sling.distribution.serialization.DistributionExportOptions;
@@ -126,7 +127,7 @@ public class FileDistributionPackageBuilder extends AbstractDistributionPackageB
             // stable id
             Map<String, Object> info = new HashMap<String, Object>();
             DistributionPackageUtils.readInfo(stream, info);
-            Object remoteId = info.get(DistributionPackageUtils.PROPERTY_REMOTE_PACKAGE_ID);
+            Object remoteId = info.get(DistributionPackageInfo.PROPERTY_REMOTE_PACKAGE_ID);
             if (remoteId != null) {
                 name = remoteId.toString();
                 log.debug("preserving remote id {}", name);

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
@@ -45,6 +45,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.packaging.DistributionPackage;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.serialization.DistributionContentSerializer;
 import org.apache.sling.distribution.serialization.DistributionExportFilter;
 import org.apache.sling.distribution.serialization.DistributionExportOptions;
@@ -193,7 +194,7 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
             Map<String, Object> info = new HashMap<String, Object>();
             DistributionPackageUtils.readInfo(stream, info);
             log.debug("read header {}", info);
-            Object remoteId = info.get(DistributionPackageUtils.PROPERTY_REMOTE_PACKAGE_ID);
+            Object remoteId = info.get(DistributionPackageInfo.PROPERTY_REMOTE_PACKAGE_ID);
             if (remoteId != null) {
                 name = remoteId.toString();
                 if (name.contains("/")) {

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageBuilder.java
@@ -77,8 +77,9 @@ public class ResourceDistributionPackageBuilder extends AbstractDistributionPack
                                               MemoryUnit memoryUnit,
                                               boolean useOffHeapMemory,
                                               String digestAlgorithm, String[] nodeFilters,
-                                              String[] propertyFilters) {
-        super(type, distributionContentSerializer.getContentType(), distributionContentSerializer.isDeletionSupported());
+                                              String[] propertyFilters,
+                                              boolean includeHeader) {
+        super(type, distributionContentSerializer.getContentType(), distributionContentSerializer.isDeletionSupported(), includeHeader);
         this.distributionContentSerializer = distributionContentSerializer;
         this.nodeFilters = VltUtils.parseFilters(nodeFilters);
         this.propertyFilters = VltUtils.parseFilters(propertyFilters);

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
@@ -93,7 +93,7 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
         DistributionPackageUtils.readInfo(stream, headerInfo);
         log.debug("header info: {}", headerInfo);
 
-        Object o = headerInfo.get(DistributionPackageUtils.PROPERTY_REMOTE_PACKAGE_ID);
+        Object o = headerInfo.get(DistributionPackageInfo.PROPERTY_REMOTE_PACKAGE_ID);
         String reference = o != null ? String.valueOf(o) : null;
 
         if (reference != null) {
@@ -124,7 +124,7 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
                     // do nothing
                 }
                 DistributionPackageInfo packageInfo;
-                Object rr = headerInfo.get("reference-required");
+                Object rr = headerInfo.get(DistributionPackageInfo.PROPERTY_REFERENCE_REQUIRED);
                 boolean store = rr != null && Boolean.valueOf(rr.toString());
                 if (store) {
                     log.debug("storing actual package");

--- a/src/main/java/org/apache/sling/distribution/queue/impl/AsyncDeliveryDispatchingStrategy.java
+++ b/src/main/java/org/apache/sling/distribution/queue/impl/AsyncDeliveryDispatchingStrategy.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.packaging.DistributionPackage;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageUtils;
 import org.apache.sling.distribution.packaging.impl.ReferencePackage;
 import org.apache.sling.distribution.packaging.impl.SharedDistributionPackage;
@@ -75,7 +76,7 @@ public class AsyncDeliveryDispatchingStrategy implements DistributionQueueDispat
             if (queue.getStatus().getItemsCount() > MAX_QUEUE_ITEMS_THRESHOLD) {
                 // too many items in the queue, let's send actual packages and references separately
 
-                distributionPackage.getInfo().put("reference-required", true);
+                distributionPackage.getInfo().put(DistributionPackageInfo.PROPERTY_REFERENCE_REQUIRED, true);
                 DistributionQueueItem item = getItem(distributionPackage);
 
                 // create and acquire reference package

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
@@ -88,6 +88,14 @@ public class DistributionPackageBuilderFactory implements DistributionPackageBui
             value = "resource", label = "type", description = "The persistence type used by this package builder")
     private static final String PERSISTENCE = DistributionComponentConstants.PN_TYPE;
 
+    /**
+     * include header
+     */
+    public static final boolean INCLUDE_HEADER_DEFAULT = true;
+    @Property(boolValue = INCLUDE_HEADER_DEFAULT, label="Include package header", description = "Whether or not to prepend the package's info as header to the package.")
+    public static final String INCLUDE_HEADER = "include-header";
+
+
     @Property(name = "format.target", label = "Content Serializer", description = "The target reference for the DistributionSerializationFormat used to (de)serialize packages, " +
             "e.g. use target=(name=...) to bind to services by name.", value = SettingsUtils.COMPONENT_NAME_DEFAULT)
     @Reference(name = "format")
@@ -203,16 +211,17 @@ public class DistributionPackageBuilderFactory implements DistributionPackageBui
         if (DEFAULT_DIGEST_ALGORITHM.equals(digestAlgorithm)) {
             digestAlgorithm = null;
         }
+        boolean includeHeader = PropertiesUtil.toBoolean(config.get(INCLUDE_HEADER), INCLUDE_HEADER_DEFAULT);
 
         DistributionPackageBuilder wrapped;
         if ("file".equals(persistenceType)) {
-            wrapped = new FileDistributionPackageBuilder(contentSerializer.getName(), contentSerializer, tempFsFolder, digestAlgorithm, nodeFilters, propertyFilters);
+            wrapped = new FileDistributionPackageBuilder(contentSerializer.getName(), contentSerializer, tempFsFolder, digestAlgorithm, nodeFilters, propertyFilters, includeHeader);
         } else {
             final int fileThreshold = PropertiesUtil.toInteger(config.get(FILE_THRESHOLD), DEFAULT_FILE_THRESHOLD_VALUE);
             String memoryUnitName = PropertiesUtil.toString(config.get(MEMORY_UNIT), DEFAULT_MEMORY_UNIT);
             final MemoryUnit memoryUnit = MemoryUnit.valueOf(memoryUnitName);
             final boolean useOffHeapMemory = PropertiesUtil.toBoolean(config.get(USE_OFF_HEAP_MEMORY), DEFAULT_USE_OFF_HEAP_MEMORY);
-            ResourceDistributionPackageBuilder resourceDistributionPackageBuilder = new ResourceDistributionPackageBuilder(contentSerializer.getName(), contentSerializer, tempFsFolder, fileThreshold, memoryUnit, useOffHeapMemory, digestAlgorithm, nodeFilters, propertyFilters);
+            ResourceDistributionPackageBuilder resourceDistributionPackageBuilder = new ResourceDistributionPackageBuilder(contentSerializer.getName(), contentSerializer, tempFsFolder, fileThreshold, memoryUnit, useOffHeapMemory, digestAlgorithm, nodeFilters, propertyFilters, includeHeader);
             Runnable cleanup = new ResourceDistributionPackageCleanup(resolverFactory, resourceDistributionPackageBuilder);
             Dictionary<String, Object> props = new Hashtable<String, Object>();
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -257,13 +257,13 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
 
         DistributionPackageBuilder wrapped;
         if ("filevlt".equals(type)) {
-            wrapped = new FileDistributionPackageBuilder(name, contentSerializer, tempFsFolder, digestAlgorithm, packageNodeFilters, packagePropertyFilters);
+            wrapped = new FileDistributionPackageBuilder(name, contentSerializer, tempFsFolder, digestAlgorithm, packageNodeFilters, packagePropertyFilters, true);
         } else {
             final int fileThreshold = PropertiesUtil.toInteger(config.get(FILE_THRESHOLD), DEFAULT_FILE_THRESHOLD_VALUE);
             String memoryUnitName = PropertiesUtil.toString(config.get(MEMORY_UNIT), DEFAULT_MEMORY_UNIT);
             final MemoryUnit memoryUnit = MemoryUnit.valueOf(memoryUnitName);
             final boolean useOffHeapMemory = PropertiesUtil.toBoolean(config.get(USE_OFF_HEAP_MEMORY), DEFAULT_USE_OFF_HEAP_MEMORY);
-            ResourceDistributionPackageBuilder resourceDistributionPackageBuilder = new ResourceDistributionPackageBuilder(contentSerializer.getName(), contentSerializer, tempFsFolder, fileThreshold, memoryUnit, useOffHeapMemory, digestAlgorithm, packageNodeFilters, packagePropertyFilters);
+            ResourceDistributionPackageBuilder resourceDistributionPackageBuilder = new ResourceDistributionPackageBuilder(contentSerializer.getName(), contentSerializer, tempFsFolder, fileThreshold, memoryUnit, useOffHeapMemory, digestAlgorithm, packageNodeFilters, packagePropertyFilters, true);
             Runnable cleanup = new ResourceDistributionPackageCleanup(resolverFactory, resourceDistributionPackageBuilder);
             Dictionary<String, Object> props = new Hashtable<String, Object>();
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);

--- a/src/main/java/org/apache/sling/distribution/transport/impl/DefaultRemoteDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/transport/impl/DefaultRemoteDistributionPackage.java
@@ -20,7 +20,7 @@
 package org.apache.sling.distribution.transport.impl;
 
 import org.apache.http.client.fluent.Executor;
-import org.apache.sling.distribution.packaging.impl.DistributionPackageUtils;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.packaging.DistributionPackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +43,7 @@ public class DefaultRemoteDistributionPackage implements RemoteDistributionPacka
         this.wrappedPackage = wrappedPackage;
         this.executor = executor;
         this.distributionURI = distributionURI;
-        this.remoteId = (String) wrappedPackage.getInfo().get(DistributionPackageUtils.PROPERTY_REMOTE_PACKAGE_ID);
+        this.remoteId = (String) wrappedPackage.getInfo().get(DistributionPackageInfo.PROPERTY_REMOTE_PACKAGE_ID);
     }
 
 

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilderTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/FileDistributionPackageBuilderTest.java
@@ -39,7 +39,7 @@ public class FileDistributionPackageBuilderTest {
     @Test
     public void testDefaultTempDirectory() throws DistributionException, IOException {
         FileDistributionPackageBuilder builder = new FileDistributionPackageBuilder("test", new TestSerializer(), null, null, new String[0],
-                new String[0]);
+                new String[0], true);
         DistributionPackage createdPackage = builder.createPackageForAdd(mock(ResourceResolver.class), mock(DistributionRequest.class));
 
         try {

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -85,7 +85,7 @@ public class LocalDistributionPackageImporterTest {
         );
 
         DistributionPackageBuilder builder =
-                new FileDistributionPackageBuilder(DistributionRequestType.ADD.name(), vaultSerializer, null, null, null, null);
+                new FileDistributionPackageBuilder(DistributionRequestType.ADD.name(), vaultSerializer, null, null, null, null, true);
 
         ResourceResolver resourceResolver = slingContext.resourceResolver();
 


### PR DESCRIPTION
This change includes a configuration about including the package metadata header in the packages binary stream or not (defaults to true, to be downwards compatible). It only applies for the DistributionPackageBuilderFactory **not** for the vlt one, as I assume vlt most likely makes only sense when integrating sling-sling.

I also moved all the constants used for DistributionPackage.getInfo() as final static fields to the DistributionPackageInfo.