### PR TITLE
SLING-7902 Fix for http.conn.timeout not being read from the configs.

### DIFF
--- a/src/main/java/org/apache/sling/distribution/agent/impl/ForwardDistributionAgentFactory.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/ForwardDistributionAgentFactory.java
@@ -246,7 +246,7 @@ public class ForwardDistributionAgentFactory extends AbstractDistributionAgentFa
         Map<String, String> priorityQueues = PropertiesUtil.toMap(config.get(PRIORITY_QUEUES), new String[0]);
         priorityQueues = SettingsUtils.removeEmptyEntries(priorityQueues);
 
-        Integer timeout = PropertiesUtil.toInteger(HTTP, 10) * 1000;
+        Integer timeout = PropertiesUtil.toInteger(config.get(HTTP), 10) * 1000;
         HttpConfiguration httpConfiguration = new HttpConfiguration(timeout);
 
         DistributionPackageExporter packageExporter = new LocalDistributionPackageExporter(packageBuilder);

--- a/src/main/java/org/apache/sling/distribution/agent/impl/ReverseDistributionAgentFactory.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/ReverseDistributionAgentFactory.java
@@ -194,7 +194,7 @@ public class ReverseDistributionAgentFactory extends AbstractDistributionAgentFa
 
         int pullItems = PropertiesUtil.toInteger(config.get(PULL_ITEMS), Integer.MAX_VALUE);
 
-        Integer timeout = PropertiesUtil.toInteger(HTTP, 10) * 1000;
+        Integer timeout = PropertiesUtil.toInteger(config.get(HTTP), 10) * 1000;
         HttpConfiguration httpConfiguration = new HttpConfiguration(timeout);
 
         DistributionPackageExporter packageExporter = new RemoteDistributionPackageExporter(distributionLog, packageBuilder,

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SyncDistributionAgentFactory.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SyncDistributionAgentFactory.java
@@ -231,7 +231,7 @@ public class SyncDistributionAgentFactory extends AbstractDistributionAgentFacto
         String[] queueNames = queuesMap.toArray(new String[queuesMap.size()]);
         exportQueueStrategy = new MultipleQueueDispatchingStrategy(queueNames);
 
-        Integer timeout = PropertiesUtil.toInteger(HTTP, 10) * 1000;
+        Integer timeout = PropertiesUtil.toInteger(config.get(HTTP), 10) * 1000;
         HttpConfiguration httpConfiguration = new HttpConfiguration(timeout);
 
         packageImporter = new RemoteDistributionPackageImporter(distributionLog, transportSecretProvider,


### PR DESCRIPTION
@npeltier , I have raised the PR as suggested. This fixes the config read issue from the http.conn.timeout field.