### PR TITLE
SLING-8668 Hook up newly introduced cugHandling option.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <dependency>
             <groupId>org.apache.jackrabbit.vault</groupId>
             <artifactId>org.apache.jackrabbit.vault</artifactId>
-            <version>3.1.42</version>
+            <version>3.2.9-SNAPSHOT</version>
         </dependency>
         <!-- HTTP -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <dependency>
             <groupId>org.apache.jackrabbit.vault</groupId>
             <artifactId>org.apache.jackrabbit.vault</artifactId>
-            <version>3.2.9-SNAPSHOT</version>
+            <version>3.4.0</version>
         </dependency>
         <!-- HTTP -->
         <dependency>

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
@@ -74,6 +74,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
     private final Packaging packaging;
     private final ImportMode importMode;
     private final AccessControlHandling aclHandling;
+    private final AccessControlHandling cugHandling;
     private final String[] packageRoots;
     private final int autosaveThreshold;
     private final TreeMap<String, List<String>> nodeFilters;
@@ -83,7 +84,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
     private final Map<String, String> exportPathMapping;
     private final boolean strict;
 
-    public FileVaultContentSerializer(String name, Packaging packaging, ImportMode importMode, AccessControlHandling aclHandling, String[] packageRoots,
+    public FileVaultContentSerializer(String name, Packaging packaging, ImportMode importMode, AccessControlHandling aclHandling, AccessControlHandling cugHandling, String[] packageRoots,
                                       String[] nodeFilters, String[] propertyFilters, boolean useBinaryReferences, int autosaveThreshold,
                                       Map<String, String> exportPathMapping,
                                       boolean strict) {
@@ -91,6 +92,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         this.packaging = packaging;
         this.importMode = importMode;
         this.aclHandling = aclHandling;
+        this.cugHandling = cugHandling;
         this.packageRoots = packageRoots;
         this.autosaveThreshold = autosaveThreshold;
         this.nodeFilters = VltUtils.parseFilters(nodeFilters);
@@ -130,7 +132,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         Archive archive = null;
         try {
             session = getSession(resourceResolver);
-            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, importMode, autosaveThreshold, strict);
+            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, cugHandling, importMode, autosaveThreshold, strict);
             Importer importer = new Importer(importOptions);
             archive = new ZipStreamArchive(inputStream);
             archive.open(false);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -100,6 +100,12 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
     private static final String ACL_HANDLING = "aclHandling";
 
     /**
+     * CUG handling property for file vault package builder
+     */
+    @Property(label = "Cug Handling", description = "The vlt cug handling mode for created packages.")
+    private static final String CUG_HANDLING = "cugHandling";
+
+    /**
      * Package roots
      */
     @Property(label = "Package Roots", description = "The package roots to be used for created packages. (this is useful for assembling packages with an user that cannot read above the package root)")
@@ -233,6 +239,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
         String type = PropertiesUtil.toString(config.get(TYPE), null);
         String importModeString = SettingsUtils.removeEmptyEntry(PropertiesUtil.toString(config.get(IMPORT_MODE), null));
         String aclHandlingString = SettingsUtils.removeEmptyEntry(PropertiesUtil.toString(config.get(ACL_HANDLING), null));
+        String cugHandlingString = SettingsUtils.removeEmptyEntry(PropertiesUtil.toString(config.get(CUG_HANDLING), null));
 
         String[] packageRoots = SettingsUtils.removeEmptyEntries(PropertiesUtil.toStringArray(config.get(PACKAGE_ROOTS), null));
         String[] packageNodeFilters = SettingsUtils.removeEmptyEntries(PropertiesUtil.toStringArray(config.get(PACKAGE_FILTERS), null));
@@ -259,13 +266,18 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
             aclHandling = AccessControlHandling.valueOf(aclHandlingString.trim());
         }
 
+        AccessControlHandling cugHandling = null;
+        if (cugHandlingString != null) {
+            cugHandling = AccessControlHandling.valueOf(cugHandlingString.trim());
+        }
+
         // check the mount path patterns, if any
         Map<String, String> pathsMapping = PropertiesUtil.toMap(config.get(PATHS_MAPPING), new String[0]);
         pathsMapping = SettingsUtils.removeEmptyEntries(pathsMapping);
 
         boolean strictImport = PropertiesUtil.toBoolean(config.get(STRICT_IMPORT_SETTINGS), DEFAULT_STRICT_IMPORT_SETTINGS);
 
-        DistributionContentSerializer contentSerializer = new FileVaultContentSerializer(name, packaging, importMode, aclHandling,
+        DistributionContentSerializer contentSerializer = new FileVaultContentSerializer(name, packaging, importMode, aclHandling, cugHandling,
                 packageRoots, packageNodeFilters, packagePropertyFilters, useBinaryReferences, autosaveThreshold, pathsMapping, strictImport);
 
         DistributionPackageBuilder wrapped;

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
@@ -226,13 +226,19 @@ public class VltUtils {
         return packageRoot;
     }
 
-    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, ImportMode importMode, int autosaveThreshold, boolean strict) {
+    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, AccessControlHandling cugHandling, ImportMode importMode, int autosaveThreshold, boolean strict) {
         ImportOptions opts = new ImportOptions();
         if (aclHandling != null) {
             opts.setAccessControlHandling(aclHandling);
         } else {
             // default to overwrite
             opts.setAccessControlHandling(AccessControlHandling.OVERWRITE);
+        }
+        if (cugHandling != null) {
+            opts.setCugHandling(cugHandling);
+        } else {
+            // default to overwrite
+            opts.setCugHandling(AccessControlHandling.OVERWRITE);
         }
         if (importMode != null) {
             opts.setImportMode(importMode);

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -83,6 +83,7 @@ public class LocalDistributionPackageImporterTest {
                 new PackagingImpl(),
                 ImportMode.UPDATE,
                 AccessControlHandling.IGNORE,
+                AccessControlHandling.IGNORE,
                 new String[0],
                 new String[0],
                 new String[0],

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
@@ -82,7 +82,7 @@ public class FileVaultContentSerializerTest {
         boolean useReferences = false;
         int threshold = 1024;
         FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
-                aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, threshold, new HashMap<String, String>(), false);
+                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, threshold, new HashMap<String, String>(), false);
 
         ResourceResolver sessionResolver = mock(ResourceResolver.class);
         Session session = mock(Session.class);
@@ -124,7 +124,7 @@ public class FileVaultContentSerializerTest {
         boolean useReferences = false;
         int thershold = 1024;
         FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
-                aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, thershold, new HashMap<String, String>(), true);
+                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, thershold, new HashMap<String, String>(), true);
 
         File file = new File(getClass().getResource("/vlt/dp.vlt").getFile());
 


### PR DESCRIPTION
This is still blocked by https://github.com/apache/jackrabbit-filevault/pull/56 and the code depends on the snapshot vault-core build from that PR.
Ones  that PR is merged we need to update org.apache.jackrabbit.vault version in pom.xml to a released version.