### PR TITLE
SLING-8869 SimpleHttpDistributionTransport does not refresh the secret for token based implementations.

### DIFF
--- a/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
+++ b/src/main/java/org/apache/sling/distribution/transport/impl/SimpleHttpDistributionTransport.java
@@ -231,18 +231,25 @@ public class SimpleHttpDistributionTransport implements DistributionTransport {
     }
 
     private Executor buildExecutor() {
-        DistributionTransportSecret secret = secretProvider.getSecret(distributionEndpoint.getUri());
-        Map<String, String> credentialsMap = secret.asCredentialsMap();
+        Map<String, String> credentialsMap = getCredentialsMap();
         return buildAuthExecutor(credentialsMap);
     }
 
     private String getAuthSecret() {
-        DistributionTransportSecret secret = secretProvider.getSecret(distributionEndpoint.getUri());
-        Map<String, String> credentialsMap = secret.asCredentialsMap();
+        Map<String, String> credentialsMap = getCredentialsMap();
         if (null != credentialsMap && credentialsMap.containsKey(AUTHORIZATION)) {
             return credentialsMap.get(AUTHORIZATION);
         }
         return null;
+    }
+    
+    private Map<String, String> getCredentialsMap() {
+        DistributionTransportSecret secret = secretProvider.getSecret(distributionEndpoint.getUri());
+        Map<String, String> credentialsMap = null;
+        if (null != secret) {
+            credentialsMap = secret.asCredentialsMap();
+        }
+        return credentialsMap;
     }
 
 }


### PR DESCRIPTION
Do not set the default authorization header at the time of creating the executor but delegate this responsibility to the issuer of the request such that everytime POST request is made, if the executor is token based, check for the expiry of the token and add the relevant header to the request.