### PR TITLE
SLING-8869 SimpleHttpDistributionTransport does not refresh the secret

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 
     <properties>
         <exam.version>4.11.0</exam.version>
+        <sling.java.version>8</sling.java.version>
     </properties>
 
     <!-- ======================================================================= -->


### PR DESCRIPTION
* most severely affecting token based implementations since renewed tokens aren't applied