### PR TITLE
SLING-8945 ActiveResourceQueue doesn't provide cluster-consistent …

### DIFF
--- a/src/main/java/org/apache/sling/distribution/queue/impl/resource/ActiveResourceQueue.java
+++ b/src/main/java/org/apache/sling/distribution/queue/impl/resource/ActiveResourceQueue.java
@@ -71,4 +71,20 @@ public class ActiveResourceQueue extends ResourceQueue {
             DistributionUtils.safelyLogout(resourceResolver);
         }
     }
+
+    public void recordProcessingAttempt(@NotNull DistributionQueueEntry entry) {
+        ResourceResolver resourceResolver = null;
+        try {
+            resourceResolver = DistributionUtils.loginService(resolverFactory, serviceName);
+            Resource queueRoot = ResourceQueueUtils.getRootResource(resourceResolver, queueRootPath);
+            Resource queueItemResource = ResourceQueueUtils.getResourceById(queueRoot, entry.getId());
+            ResourceQueueUtils.incrementProcessingAttemptForQueueItem(queueItemResource);
+            resourceResolver.commit();
+            log.debug("incremented processing-attempt for queue entry with id: {}", entry.getId());
+        } catch (Exception e) {
+            log.warn("Couldn't increment processing-attempt for queue entry with id: {}", entry.getId());
+        } finally {
+            DistributionUtils.safelyLogout(resourceResolver);
+        }
+    }
 }

--- a/src/main/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueueProvider.java
+++ b/src/main/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueueProvider.java
@@ -23,7 +23,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.distribution.common.DistributionException;
-import org.apache.sling.distribution.queue.DistributionQueueItemStatus;
+import org.apache.sling.distribution.queue.DistributionQueueEntry;
 import org.apache.sling.distribution.queue.DistributionQueueType;
 import org.apache.sling.distribution.queue.impl.DistributionQueueProcessor;
 import org.apache.sling.distribution.queue.impl.DistributionQueueProvider;
@@ -40,6 +40,7 @@ import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 public class ResourceQueueProvider implements DistributionQueueProvider {
     public static final String TYPE = "resource";
@@ -56,9 +57,6 @@ public class ResourceQueueProvider implements DistributionQueueProvider {
     private boolean isActive;
 
     private final Map<String, ResourceQueue> queueMap = new ConcurrentHashMap<>();
-
-    private final Map<String, Map<String, DistributionQueueItemStatus>> statusMap = new ConcurrentHashMap<>();
-
 
     private ServiceRegistration<Runnable> cleanupTask;
 
@@ -81,13 +79,11 @@ public class ResourceQueueProvider implements DistributionQueueProvider {
     @NotNull
     @Override
     public DistributionQueue getQueue(@NotNull String queueName) throws DistributionException {
-        String key = getKey(queueName);
-        return queueMap.computeIfAbsent(key, k -> {
-            statusMap.put(key, new ConcurrentHashMap<>());
+        return queueMap.computeIfAbsent(queueName, name -> {
             if (isActive) {
-                return new ActiveResourceQueue(resolverFactory, serviceName, queueName, agentRootPath);
+                return new ActiveResourceQueue(resolverFactory, serviceName, name, agentRootPath);
             } else {
-                return new ResourceQueue(resolverFactory, serviceName, queueName, agentRootPath);
+                return new ResourceQueue(resolverFactory, serviceName, name, agentRootPath);
             }
         });
     }
@@ -111,8 +107,13 @@ public class ResourceQueueProvider implements DistributionQueueProvider {
                         .canRunConcurrently(false)
                         .onSingleInstanceOnly(true)
                         .name(getJobName(queueName));
-                scheduler.schedule(new SimpleDistributionQueueProcessor(getQueue(queueName), queueProcessor,
-                        statusMap.get(getKey(queueName))), options);
+                DistributionQueue queueImpl = getQueue(queueName);
+                Consumer<DistributionQueueEntry> processingAttemptRecorder = null;
+                if (isActive) {
+                    processingAttemptRecorder = ((ActiveResourceQueue)queueImpl)::recordProcessingAttempt;
+                }
+                scheduler.schedule(new SimpleDistributionQueueProcessor(queueImpl, queueProcessor, processingAttemptRecorder),
+                        options);
             }
         } else {
             throw new DistributionException(new UnsupportedOperationException("enable Processing not supported for Passive Queues"));
@@ -148,10 +149,6 @@ public class ResourceQueueProvider implements DistributionQueueProvider {
         props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);
         props.put(Scheduler.PROPERTY_SCHEDULER_PERIOD, 300L);
         cleanupTask = context.registerService(Runnable.class, cleanup, props);
-    }
-
-    private String getKey(String queueName) {
-        return agentName + "#" + queueName;
     }
 
     public void close() {

--- a/src/main/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueueUtils.java
+++ b/src/main/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueueUtils.java
@@ -20,6 +20,7 @@
 package org.apache.sling.distribution.queue.impl.resource;
 
 
+import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -70,6 +71,7 @@ public class ResourceQueueUtils {
     private static final String DISTRIBUTION_PACKAGE_ID = DISTRIBUTION_PACKAGE_PREFIX + "item.id";
     private static final String DISTRIBUTION_PACKAGE_SIZE = DISTRIBUTION_PACKAGE_PREFIX + "package.size";
     private static final String ENTERED_DATE = "entered.date";
+    private static final String PROCESSING_ATTEMPTS = "processing.attempts";
 
 
     private static final AtomicLong itemCounter = new AtomicLong(0);
@@ -145,8 +147,9 @@ public class ResourceQueueUtils {
         ValueMap valueMap = resource.getValueMap();
         DistributionQueueItem queueItem = deserializeItem(valueMap);
         Calendar entered = valueMap.get(ENTERED_DATE, Calendar.getInstance());
+        int attempts = valueMap.get(PROCESSING_ATTEMPTS, 0);
         DistributionQueueItemStatus queueItemStatus = new DistributionQueueItemStatus(entered,
-                DistributionQueueItemState.QUEUED, 0, queueName);
+                DistributionQueueItemState.QUEUED, attempts, queueName);
 
         String entryId = getIdFromPath(queueRoot.getPath(), resource.getPath());
 
@@ -418,6 +421,12 @@ public class ResourceQueueUtils {
         }
 
         return itemId.replace(ID_START, "").replace("--", "/");
+    }
+
+    public static void incrementProcessingAttemptForQueueItem(Resource queueItemResource) {
+        ValueMap vm = queueItemResource.adaptTo(ModifiableValueMap.class);
+        int attempts = vm.get(PROCESSING_ATTEMPTS, 0);
+        vm.put(PROCESSING_ATTEMPTS, attempts + 1);
     }
 
 }

--- a/src/test/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentTest.java
+++ b/src/test/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentTest.java
@@ -21,7 +21,6 @@ package org.apache.sling.distribution.agent.impl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.distribution.DistributionRequest;
@@ -125,7 +124,7 @@ public class SimpleDistributionAgentTest {
 
 
         when(queueProvider.getQueue(DistributionQueueDispatchingStrategy.DEFAULT_QUEUE_NAME)).thenReturn(
-                new SimpleDistributionQueue(name, "name", new HashMap<String, DistributionQueueItemStatus>()));
+                new SimpleDistributionQueue(name, "name"));
         DistributionResponse response = agent.execute(resourceResolver, request);
         assertNotNull(response);
         assertEquals("[ERROR]", response.getMessage());
@@ -165,7 +164,7 @@ public class SimpleDistributionAgentTest {
             }
         }).when(packageExporter).exportPackages(any(ResourceResolver.class), any(DistributionRequest.class), any(DistributionPackageProcessor.class));
         when(queueProvider.getQueue(DistributionQueueDispatchingStrategy.DEFAULT_QUEUE_NAME)).thenReturn(
-                new SimpleDistributionQueue(name, "name", new HashMap<String, DistributionQueueItemStatus>()));
+                new SimpleDistributionQueue(name, "name"));
         DistributionResponse response = agent.execute(resourceResolver, request);
         assertNotNull(response);
         assertEquals("[QUEUED]", response.getMessage());
@@ -205,7 +204,7 @@ public class SimpleDistributionAgentTest {
                 return null;
             }
         }).when(packageExporter).exportPackages(any(ResourceResolver.class), any(DistributionRequest.class), any(DistributionPackageProcessor.class));        when(queueProvider.getQueue(DistributionQueueDispatchingStrategy.DEFAULT_QUEUE_NAME)).thenReturn(
-                new SimpleDistributionQueue(name, "name", new HashMap<String, DistributionQueueItemStatus>()));
+                new SimpleDistributionQueue(name, "name"));
 
         agent.execute(resourceResolver, request);
     }
@@ -298,7 +297,7 @@ public class SimpleDistributionAgentTest {
                 return null;
             }
         }).when(packageExporter).exportPackages(any(ResourceResolver.class), any(DistributionRequest.class), any(DistributionPackageProcessor.class));        when(queueProvider.getQueue(DistributionQueueDispatchingStrategy.DEFAULT_QUEUE_NAME)).thenReturn(
-                new SimpleDistributionQueue(name, "name", new HashMap<String, DistributionQueueItemStatus>()));
+                new SimpleDistributionQueue(name, "name"));
 
         DistributionResponse response = agent.execute(resourceResolver, request);
 
@@ -344,7 +343,7 @@ public class SimpleDistributionAgentTest {
                 return null;
             }
         }).when(packageExporter).exportPackages(any(ResourceResolver.class), any(DistributionRequest.class), any(DistributionPackageProcessor.class));        when(queueProvider.getQueue(DistributionQueueDispatchingStrategy.DEFAULT_QUEUE_NAME)).thenReturn(
-                new SimpleDistributionQueue(name, "name", new HashMap<String, DistributionQueueItemStatus>()));
+                new SimpleDistributionQueue(name, "name"));
 
         DistributionResponse response = agent.execute(resourceResolver, request);
 

--- a/src/test/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueueProcessingTest.java
+++ b/src/test/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueueProcessingTest.java
@@ -87,7 +87,7 @@ public class ResourceQueueProcessingTest {
             assertEquals(MAX_ENTRIES, resourceQueue.getStatus().getItemsCount());
 
             when(mockResourceQueueProcessor.process(eq(QUEUE_NAME), Matchers.any(DistributionQueueEntry.class)))
-                .thenReturn(true);
+                .thenReturn(false, true);
 
             resourceQueueProvider.enableQueueProcessing(mockResourceQueueProcessor, QUEUE_NAME);
             while (!resourceQueue.getStatus().getState().equals(DistributionQueueState.IDLE)) {

--- a/src/test/java/org/apache/sling/distribution/queue/impl/simple/SimpleDistributionQueueProcessorTest.java
+++ b/src/test/java/org/apache/sling/distribution/queue/impl/simple/SimpleDistributionQueueProcessorTest.java
@@ -21,6 +21,7 @@ package org.apache.sling.distribution.queue.impl.simple;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
+
 import org.apache.sling.distribution.queue.DistributionQueueItemState;
 import org.apache.sling.distribution.queue.DistributionQueueItemStatus;
 import org.apache.sling.distribution.queue.spi.DistributionQueue;
@@ -28,7 +29,6 @@ import org.apache.sling.distribution.queue.DistributionQueueEntry;
 import org.apache.sling.distribution.queue.DistributionQueueItem;
 import org.apache.sling.distribution.queue.impl.DistributionQueueProcessor;
 import org.junit.Test;
-
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +42,7 @@ public class SimpleDistributionQueueProcessorTest {
         DistributionQueue queue = mock(DistributionQueue.class);
         DistributionQueueProcessor queueProcessor = mock(DistributionQueueProcessor.class);
         SimpleDistributionQueueProcessor simpleDistributionQueueProcessor = new SimpleDistributionQueueProcessor(
-                queue, queueProcessor, new HashMap<String, DistributionQueueItemStatus>());
+                queue, queueProcessor, null);
         simpleDistributionQueueProcessor.run();
     }
 
@@ -56,7 +56,7 @@ public class SimpleDistributionQueueProcessorTest {
         when(queueProvider.getQueues()).thenReturn(queues);
         DistributionQueueProcessor queueProcessor = mock(DistributionQueueProcessor.class);
         SimpleDistributionQueueProcessor simpleDistributionQueueProcessor = new SimpleDistributionQueueProcessor(
-                queue, queueProcessor, new HashMap<String, DistributionQueueItemStatus>());
+                queue, queueProcessor, null);
         simpleDistributionQueueProcessor.run();
     }
 
@@ -73,7 +73,7 @@ public class SimpleDistributionQueueProcessorTest {
         when(queueProvider.getQueues()).thenReturn(queues);
         DistributionQueueProcessor queueProcessor = mock(DistributionQueueProcessor.class);
         SimpleDistributionQueueProcessor simpleDistributionQueueProcessor = new SimpleDistributionQueueProcessor(
-                queue, queueProcessor, new HashMap<String, DistributionQueueItemStatus>());
+                queue, queueProcessor, queue::recordProcessingAttempt);
         simpleDistributionQueueProcessor.run();
     }
 }

--- a/src/test/java/org/apache/sling/distribution/queue/impl/simple/SimpleDistributionQueueTest.java
+++ b/src/test/java/org/apache/sling/distribution/queue/impl/simple/SimpleDistributionQueueTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.distribution.queue.impl.simple;
 
 import java.util.HashMap;
+
 import org.apache.sling.distribution.queue.spi.DistributionQueue;
 import org.apache.sling.distribution.queue.DistributionQueueEntry;
 import org.apache.sling.distribution.queue.DistributionQueueItem;
@@ -38,8 +39,7 @@ public class SimpleDistributionQueueTest {
 
     @Test
     public void testPackageAddition() throws Exception {
-        DistributionQueue queue = new SimpleDistributionQueue("agentName", "default",
-                new HashMap<String, DistributionQueueItemStatus>());
+        DistributionQueue queue = new SimpleDistributionQueue("agentName", "default");
         DistributionQueueItem pkg = new DistributionQueueItem("packageId", new HashMap<String, Object>());
         assertNotNull(queue.add(pkg));
         assertFalse(queue.getStatus().isEmpty());
@@ -47,8 +47,7 @@ public class SimpleDistributionQueueTest {
 
     @Test
     public void testPackageAdditionAndRemoval() throws Exception {
-        DistributionQueue queue = new SimpleDistributionQueue("agentName", "default",
-                new HashMap<String, DistributionQueueItemStatus>());
+        DistributionQueue queue = new SimpleDistributionQueue("agentName", "default");
         DistributionQueueItem pkg = new DistributionQueueItem("id", new HashMap<String, Object>());
         assertNotNull(queue.add(pkg));
         assertFalse(queue.getStatus().isEmpty());
@@ -60,18 +59,26 @@ public class SimpleDistributionQueueTest {
 
     @Test
     public void testPackageAdditionRetrievalAndRemoval() throws Exception {
-        DistributionQueue queue = new SimpleDistributionQueue("agentName", "default",
-                new HashMap<String, DistributionQueueItemStatus>());
+        DistributionQueue queue = new SimpleDistributionQueue("agentName", "default");
         DistributionQueueItem pkg = new DistributionQueueItem("id", new HashMap<String, Object>());
         assertNotNull(queue.add(pkg));
         assertFalse(queue.getStatus().isEmpty());
-        assertEquals(pkg, queue.getHead().getItem());
-        assertFalse(queue.getStatus().isEmpty());
+        DistributionQueueEntry entry = queue.getHead();
+
         DistributionQueueItemStatus status = queue.getEntry(pkg.getPackageId()).getStatus();
+        assertNotNull(status);
+        assertEquals(0, status.getAttempts());
+
+        ((SimpleDistributionQueue)queue).recordProcessingAttempt(entry);
+
+        assertEquals(pkg, entry.getItem());
+        assertFalse(queue.getStatus().isEmpty());
+
+        status = queue.getEntry(pkg.getPackageId()).getStatus();
         assertNotNull(queue.remove(pkg.getPackageId()));
         assertTrue(queue.getStatus().isEmpty());
         assertNotNull(status);
-        assertEquals(0, status.getAttempts());
+        assertEquals(1, status.getAttempts());
     }
 
 }


### PR DESCRIPTION
…processing-attempts view

* refactors the code a bit to (a state before #26 was merged) contain status recording within queue instances themselves, freeing Queue Provider from the responsibility of maintaining them for the queues they create