### PR TITLE
SLING-9016 Distribution Event should be generated when the package is…

### DIFF
--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -157,6 +157,8 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
 
                     if (errorQueueStrategy != null && queueItemStatus.getAttempts() > retryAttempts) {
                         removeItemFromQueue = reEnqueuePackage(distributionPackage);
+                        distributionEventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DROPPED,
+                                DistributionComponentKind.AGENT, agentName, distributionPackage.getInfo());
                         distributionLog.info("[{}] PACKAGE-QUEUED {}: distribution package {} was enqueued to an error queue", queueName, requestId, distributionPackage.getId());
                     }
                 }


### PR DESCRIPTION
…dropped

* For SimpleDistributionAgentQueueProcessor, the only time a package is dropped would be if a valid error strategy is configured and retries have exceeded max-retry-attempts configured