### PR TITLE
SLING-9363 SimpleDistributionAgentQueueProcessor performs duplicate logging

### DIFF
--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -145,17 +145,10 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
                             endTime - startTime, endTime - globalStartTime,
                             packageSize);
                 } catch (RecoverableDistributionException e) {
-                    distributionLog.error("[{}] PACKAGE-FAIL {}: could not deliver {}, {}", queueName, requestId, distributionPackage.getId(), e.getMessage());
+                    distributionLog.warn("[{}] PACKAGE-FAIL {}: could not deliver {}, {}", queueName, requestId, distributionPackage.getId(), e.getMessage());
                     distributionLog.debug("could not deliver package {}", distributionPackage.getId(), e);
-
-                    log.warn("could not deliver package {} due to {}, will retry", distributionPackage.getId(), e.getMessage());
-                    log.debug("Stacktrace: ", e);
-
                 } catch (Throwable e) {
                     distributionLog.error("[{}] PACKAGE-FAIL {}: could not deliver package {} {}", queueName, requestId, distributionPackage.getId(), e.getMessage(), e);
-
-                    log.error("could not deliver package {} from queue {}", new Object[]{distributionPackage.getId(), queueName}, e);
-
                     if (errorQueueStrategy != null && queueItemStatus.getAttempts() > retryAttempts) {
                         removeItemFromQueue = reEnqueuePackage(distributionPackage);
                         distributionEventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DROPPED,

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageCleanup.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageCleanup.java
@@ -71,7 +71,7 @@ public class ResourceDistributionPackageCleanup implements Runnable {
                 serviceResolver.commit();
             }
             log.debug("Cleaned up {}/{} {} packages",
-                    new Object[]{deleted, total, packageBuilder.getType()});
+                    deleted, total, packageBuilder.getType());
         } catch (LoginException e) {
             log.error("Failed to get distribution service resolver: {}", e.getMessage());
         } catch (DistributionException e) {

--- a/src/main/java/org/apache/sling/distribution/queue/impl/jobhandling/JobHandlingDistributionQueue.java
+++ b/src/main/java/org/apache/sling/distribution/queue/impl/jobhandling/JobHandlingDistributionQueue.java
@@ -110,7 +110,8 @@ public class JobHandlingDistributionQueue implements DistributionQueue {
         if (jobs.size() > 0) {
             Job firstItem = jobs.get(0);
             log.debug("first item in the queue is {}, retried {} times, state {}",
-                    new Object[]{ firstItem.getId(), firstItem.getRetryCount(), firstItem.getJobState() });            return firstItem;
+                    firstItem.getId(), firstItem.getRetryCount(), firstItem.getJobState());
+            return firstItem;
         }
         return null;
     }
@@ -123,7 +124,7 @@ public class JobHandlingDistributionQueue implements DistributionQueue {
             log.warn("item with id {} cannot be found", itemId);
         } else {
             log.debug("retrieved item with id {}, retried {} times, state {}",
-                    new Object[]{ job.getId(), job.getRetryCount(), job.getJobState() });
+                    job.getId(), job.getRetryCount(), job.getJobState());
         }
 
         return job;

--- a/src/main/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueue.java
+++ b/src/main/java/org/apache/sling/distribution/queue/impl/resource/ResourceQueue.java
@@ -135,7 +135,7 @@ public class ResourceQueue implements DistributionQueue {
 
             List<DistributionQueueEntry> entries =  ResourceQueueUtils.getEntries(queueRoot, skip, limit);
 
-            log.debug("queue[{}] getEntries entries={}", new Object[] { queueName, entries.size() });
+            log.debug("queue[{}] getEntries entries={}", queueName, entries.size());
 
             return entries;
         } catch (LoginException e) {

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageExporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageExporterServlet.java
@@ -121,7 +121,7 @@ public class DistributionPackageExporterServlet extends SlingAllMethodsServlet {
 
                     // everything ok
                     response.setStatus(200);
-                    log.debug("exported package {} was sent (and deleted={}), bytes written {}", new Object[]{packageId, delete, bytesCopied});
+                    log.debug("exported package {} was sent (and deleted={}), bytes written {}", packageId, delete, bytesCopied);
                 }
 
                 @Override
@@ -142,7 +142,7 @@ public class DistributionPackageExporterServlet extends SlingAllMethodsServlet {
 
             if (fetched.get() > 0) {
                 long end = System.currentTimeMillis();
-                log.info("Processed distribution export request in {} ms: : fetched {}", new Object[]{end - start, fetched});
+                log.info("Processed distribution export request in {} ms: : fetched {}", end - start, fetched);
             } else {
                 response.setStatus(204);
                 log.debug("nothing to fetch");

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
@@ -79,8 +79,7 @@ public class DistributionPackageImporterServlet extends SlingAllMethodsServlet {
                 digestAlgorithm = matcher.group(1);
                 digestMessage = matcher.group(2);
             } else {
-                log.debug("Digest header {} not supported, it doesn't match with expected pattern {}",
-                          new Object[]{ digestHeader, digestHeaderRegex.pattern() });
+                log.debug("Digest header {} not supported, it doesn't match with expected pattern {}", digestHeader, digestHeaderRegex.pattern());
             }
         }
 
@@ -108,7 +107,7 @@ public class DistributionPackageImporterServlet extends SlingAllMethodsServlet {
                 String receivedDigestMessage = readDigestMessage((DigestInputStream) stream);
                 if (!digestMessage.equalsIgnoreCase(receivedDigestMessage)) {
                     log.error("Error during distribution import: received distribution package is corrupted, expected [{}] but received [{}]",
-                              new Object[]{ digestMessage, receivedDigestMessage });
+                              digestMessage, receivedDigestMessage);
                     Map<String, String> kv = new HashMap<String, String>();
                     kv.put("digestAlgorithm", digestAlgorithm);
                     kv.put("expected", digestMessage);

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionTriggerServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionTriggerServlet.java
@@ -123,6 +123,6 @@ public class DistributionTriggerServlet extends SlingAllMethodsServlet {
 
         // flush the buffers to make sure the container sends the bytes
         writer.flush();
-        log.debug("SSE event {} {}", new Object[]{distributionRequest.getRequestType(), distributionRequest.getPaths()});
+        log.debug("SSE event {} {}", distributionRequest.getRequestType(), distributionRequest.getPaths());
     }
 }

--- a/src/main/java/org/apache/sling/distribution/trigger/impl/RemoteEventDistributionTrigger.java
+++ b/src/main/java/org/apache/sling/distribution/trigger/impl/RemoteEventDistributionTrigger.java
@@ -121,15 +121,15 @@ public class RemoteEventDistributionTrigger implements DistributionTrigger {
             log.debug("complete {}", decoder.isCompleted());
             ByteBuffer buffer = ByteBuffer.allocate(1024);
             decoder.read(buffer);
-            log.debug("content {} received {},{}", new Object[]{buffer, decoder, ioctrl});
+            log.debug("content {} received {},{}", buffer, decoder, ioctrl);
 
             // TODO : currently it always triggers pull request on /, should this be configurable?
             DistributionRequest distributionRequest = new SimpleDistributionRequest(DistributionRequestType.PULL, "/");
             handler.handle(null, distributionRequest);
-            log.info("distribution request to agent {} sent ({} {})", new Object[]{
+            log.info("distribution request to agent {} sent ({} {})",
                     handler,
                     distributionRequest.getRequestType(),
-                    distributionRequest.getPaths()});
+                    distributionRequest.getPaths());
 
             super.onContentReceived(decoder, ioctrl);
         }

--- a/src/main/java/org/apache/sling/distribution/trigger/impl/ScheduledDistributionTrigger.java
+++ b/src/main/java/org/apache/sling/distribution/trigger/impl/ScheduledDistributionTrigger.java
@@ -128,7 +128,7 @@ public class ScheduledDistributionTrigger implements DistributionTrigger {
         }
 
         public void run() {
-            log.debug("agent {}: scheduling {} distribution of {}", new Object[]{requestHandler, distributionAction, path});
+            log.debug("agent {}: scheduling {} distribution of {}", requestHandler, distributionAction, path);
 
             if (serviceName == null) {
                 requestHandler.handle(null, new SimpleDistributionRequest(distributionAction, path));


### PR DESCRIPTION
* also fixed log-statements to be compatible with slf4j v1.7.6
  as specified in sling-28 parent-pom artifact [0] (which being used in the bundle [1])

[0] https://github.com/apache/sling-parent/blob/0322917ff27cf3674a3a1cf9ed26dc59a2c5a9ce/pom.xml#L360
[1] https://github.com/apache/sling-org-apache-sling-distribution-core/blob/d3453cf14116e1343717ea600dae4bd1b4ef7afb/pom.xml#L28