### PR TITLE
SLING-9389: Distribution Event Packages should contain queue item creation time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.distribution.api</artifactId>
-            <version>0.4.0</version>
+            <version>0.4.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
@@ -21,8 +21,10 @@ package org.apache.sling.distribution.agent.impl;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.sling.distribution.DistributionRequestState;
 import org.apache.sling.distribution.DistributionResponse;
 import org.apache.sling.distribution.common.DistributionException;
@@ -36,8 +38,8 @@ import org.apache.sling.distribution.packaging.impl.DistributionPackageProcessor
 import org.apache.sling.distribution.packaging.impl.DistributionPackageUtils;
 import org.apache.sling.distribution.queue.DistributionQueueItemState;
 import org.apache.sling.distribution.queue.DistributionQueueItemStatus;
-import org.apache.sling.distribution.queue.impl.DistributionQueueProvider;
 import org.apache.sling.distribution.queue.impl.DistributionQueueDispatchingStrategy;
+import org.apache.sling.distribution.queue.impl.DistributionQueueProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -127,7 +129,7 @@ class QueueingDistributionPackageProcessor implements DistributionPackageProcess
 
             distributionEventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_QUEUED,
                     DistributionComponentKind.AGENT, agentName, distributionPackage.getInfo(),
-                    null);
+                    Optional.empty());
         } catch (DistributionException e) {
             log.error("an error happened during dispatching items to the queue(s)", e);
             distributionResponses.add(new SimpleDistributionResponse(DistributionRequestState.DROPPED, e.toString()));

--- a/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.sling.distribution.agent.impl;
 
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.distribution.agent.impl;
 
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -126,7 +127,8 @@ class QueueingDistributionPackageProcessor implements DistributionPackageProcess
             }
 
             distributionEventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_QUEUED,
-                    DistributionComponentKind.AGENT, agentName, distributionPackage.getInfo());
+                    DistributionComponentKind.AGENT, agentName, distributionPackage.getInfo(),
+                    null);
         } catch (DistributionException e) {
             log.error("an error happened during dispatching items to the queue(s)", e);
             distributionResponses.add(new SimpleDistributionResponse(DistributionRequestState.DROPPED, e.toString()));

--- a/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/QueueingDistributionPackageProcessor.java
@@ -21,7 +21,6 @@ package org.apache.sling.distribution.agent.impl;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -129,7 +128,7 @@ class QueueingDistributionPackageProcessor implements DistributionPackageProcess
 
             distributionEventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_QUEUED,
                     DistributionComponentKind.AGENT, agentName, distributionPackage.getInfo(),
-                    Optional.empty());
+                    null);
         } catch (DistributionException e) {
             log.error("an error happened during dispatching items to the queue(s)", e);
             distributionResponses.add(new SimpleDistributionResponse(DistributionRequestState.DROPPED, e.toString()));

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgent.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgent.java
@@ -18,14 +18,21 @@
  */
 package org.apache.sling.distribution.agent.impl;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.DistributionRequestState;
 import org.apache.sling.distribution.DistributionRequestType;
 import org.apache.sling.distribution.DistributionResponse;
-import org.apache.sling.distribution.agent.spi.DistributionAgent;
 import org.apache.sling.distribution.agent.DistributionAgentState;
+import org.apache.sling.distribution.agent.spi.DistributionAgent;
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.component.impl.DistributionComponentKind;
 import org.apache.sling.distribution.component.impl.SettingsUtils;
@@ -33,28 +40,22 @@ import org.apache.sling.distribution.event.DistributionEventTopics;
 import org.apache.sling.distribution.event.impl.DistributionEventFactory;
 import org.apache.sling.distribution.impl.CompositeDistributionResponse;
 import org.apache.sling.distribution.impl.SimpleDistributionResponse;
-import org.apache.sling.distribution.log.spi.DistributionLog;
 import org.apache.sling.distribution.log.impl.DefaultDistributionLog;
+import org.apache.sling.distribution.log.spi.DistributionLog;
 import org.apache.sling.distribution.packaging.DistributionPackage;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageExporter;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageImporter;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageProcessor;
-import org.apache.sling.distribution.queue.spi.DistributionQueue;
-import org.apache.sling.distribution.queue.impl.DistributionQueueProcessor;
-import org.apache.sling.distribution.queue.impl.DistributionQueueProvider;
 import org.apache.sling.distribution.queue.DistributionQueueState;
 import org.apache.sling.distribution.queue.impl.DistributionQueueDispatchingStrategy;
+import org.apache.sling.distribution.queue.impl.DistributionQueueProcessor;
+import org.apache.sling.distribution.queue.impl.DistributionQueueProvider;
 import org.apache.sling.distribution.queue.impl.SimpleAgentDistributionQueue;
+import org.apache.sling.distribution.queue.spi.DistributionQueue;
 import org.apache.sling.distribution.trigger.DistributionTrigger;
 import org.apache.sling.distribution.util.impl.DistributionUtils;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Basic implementation of a {@link DistributionAgent}
  */
@@ -355,8 +356,8 @@ public class SimpleDistributionAgent implements DistributionAgent {
 
     private void generatePackageEvent(String topic, DistributionPackage... distributionPackages) {
         for (DistributionPackage distributionPackage : distributionPackages) {
-            distributionEventFactory.generatePackageEvent(topic, DistributionComponentKind.AGENT, name, distributionPackage.getInfo(),
-                null);
+            distributionEventFactory.generatePackageEvent(topic, DistributionComponentKind.AGENT, name,
+                distributionPackage.getInfo(), Optional.empty());
         }
     }
 

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgent.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgent.java
@@ -20,7 +20,6 @@ package org.apache.sling.distribution.agent.impl;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -357,7 +356,7 @@ public class SimpleDistributionAgent implements DistributionAgent {
     private void generatePackageEvent(String topic, DistributionPackage... distributionPackages) {
         for (DistributionPackage distributionPackage : distributionPackages) {
             distributionEventFactory.generatePackageEvent(topic, DistributionComponentKind.AGENT, name,
-                distributionPackage.getInfo(), Optional.empty());
+                distributionPackage.getInfo(), null);
         }
     }
 

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgent.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgent.java
@@ -355,7 +355,8 @@ public class SimpleDistributionAgent implements DistributionAgent {
 
     private void generatePackageEvent(String topic, DistributionPackage... distributionPackages) {
         for (DistributionPackage distributionPackage : distributionPackages) {
-            distributionEventFactory.generatePackageEvent(topic, DistributionComponentKind.AGENT, name, distributionPackage.getInfo());
+            distributionEventFactory.generatePackageEvent(topic, DistributionComponentKind.AGENT, name, distributionPackage.getInfo(),
+                null);
         }
     }
 

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -19,6 +19,8 @@
 package org.apache.sling.distribution.agent.impl;
 
 import java.util.Calendar;
+import java.util.Optional;
+
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.distribution.DistributionRequestType;
 import org.apache.sling.distribution.common.DistributionException;
@@ -110,7 +112,7 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
         DistributionQueueItem queueItem = queueEntry.getItem();
         DistributionQueueItemStatus queueItemStatus = queueEntry.getStatus();
         
-        final Calendar queueItemCreationTime = queueItemStatus.getEntered();
+        final Optional<Calendar> queueItemCreationTime = Optional.of(queueItemStatus.getEntered());
         try {
 
             String callingUser = queueItem.get(DistributionPackageUtils.PACKAGE_INFO_PROPERTY_REQUEST_USER, String.class);

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.sling.distribution.agent.impl;
 
 import java.util.Calendar;
-
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.distribution.DistributionRequestType;
 import org.apache.sling.distribution.common.DistributionException;

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -19,7 +19,6 @@
 package org.apache.sling.distribution.agent.impl;
 
 import java.util.Calendar;
-import java.util.Optional;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.distribution.DistributionRequestType;
@@ -112,7 +111,7 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
         DistributionQueueItem queueItem = queueEntry.getItem();
         DistributionQueueItemStatus queueItemStatus = queueEntry.getStatus();
         
-        final Optional<Calendar> queueItemCreationTime = Optional.of(queueItemStatus.getEntered());
+        final Calendar queueItemCreationTime = queueItemStatus.getEntered();
         try {
 
             String callingUser = queueItem.get(DistributionPackageUtils.PACKAGE_INFO_PROPERTY_REQUEST_USER, String.class);

--- a/src/main/java/org/apache/sling/distribution/event/impl/DefaultDistributionEventFactory.java
+++ b/src/main/java/org/apache/sling/distribution/event/impl/DefaultDistributionEventFactory.java
@@ -21,7 +21,7 @@ package org.apache.sling.distribution.event.impl;
 import java.util.Calendar;
 import java.util.Dictionary;
 import java.util.Hashtable;
-
+import java.util.Optional;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
@@ -52,7 +52,8 @@ public class DefaultDistributionEventFactory implements DistributionEventFactory
     }
 
     public void generatePackageEvent(@NotNull String distributionEventTopic, @NotNull DistributionComponentKind kind,
-                                     @NotNull String name, @NotNull DistributionPackageInfo info, Calendar queueItemCreationTime) {
+                                     @NotNull String name, @NotNull DistributionPackageInfo info,
+                                     Optional<Calendar> queueItemCreationTime) {
         try {
             Dictionary<String, Object> dictionary = new Hashtable<String, Object>();
             dictionary.put(DistributionEventProperties.DISTRIBUTION_COMPONENT_NAME, name);
@@ -63,12 +64,10 @@ public class DefaultDistributionEventFactory implements DistributionEventFactory
             if (info.getPaths() != null) {
                 dictionary.put(DistributionEventProperties.DISTRIBUTION_PATHS, info.getPaths());
             }
-            
-            if(null != queueItemCreationTime) {
-                dictionary.put(DistributionEventProperties.DISTRIBUTION_ENQUEUE_TIMESTAMP, queueItemCreationTime.getTimeInMillis());
-            }
-            generateEvent(distributionEventTopic, dictionary);
+            queueItemCreationTime.ifPresent(
+                    time -> dictionary.put(DistributionEventProperties.DISTRIBUTION_ENQUEUE_TIMESTAMP, time.getTimeInMillis()));
 
+            generateEvent(distributionEventTopic, dictionary);
         } catch (Throwable e) {
             log.error("Cannot generate package event", e);
         }

--- a/src/main/java/org/apache/sling/distribution/event/impl/DefaultDistributionEventFactory.java
+++ b/src/main/java/org/apache/sling/distribution/event/impl/DefaultDistributionEventFactory.java
@@ -21,7 +21,6 @@ package org.apache.sling.distribution.event.impl;
 import java.util.Calendar;
 import java.util.Dictionary;
 import java.util.Hashtable;
-import java.util.Optional;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
@@ -53,7 +52,7 @@ public class DefaultDistributionEventFactory implements DistributionEventFactory
 
     public void generatePackageEvent(@NotNull String distributionEventTopic, @NotNull DistributionComponentKind kind,
                                      @NotNull String name, @NotNull DistributionPackageInfo info,
-                                     Optional<Calendar> queueItemCreationTime) {
+                                     Calendar queueItemCreationTime) {
         try {
             Dictionary<String, Object> dictionary = new Hashtable<String, Object>();
             dictionary.put(DistributionEventProperties.DISTRIBUTION_COMPONENT_NAME, name);
@@ -64,8 +63,10 @@ public class DefaultDistributionEventFactory implements DistributionEventFactory
             if (info.getPaths() != null) {
                 dictionary.put(DistributionEventProperties.DISTRIBUTION_PATHS, info.getPaths());
             }
-            queueItemCreationTime.ifPresent(
-                    time -> dictionary.put(DistributionEventProperties.DISTRIBUTION_ENQUEUE_TIMESTAMP, time.getTimeInMillis()));
+
+            if(null != queueItemCreationTime) {
+                dictionary.put(DistributionEventProperties.DISTRIBUTION_ENQUEUE_TIMESTAMP, queueItemCreationTime.getTimeInMillis());
+            }
 
             generateEvent(distributionEventTopic, dictionary);
         } catch (Throwable e) {

--- a/src/main/java/org/apache/sling/distribution/event/impl/DefaultDistributionEventFactory.java
+++ b/src/main/java/org/apache/sling/distribution/event/impl/DefaultDistributionEventFactory.java
@@ -18,8 +18,10 @@
  */
 package org.apache.sling.distribution.event.impl;
 
+import java.util.Calendar;
 import java.util.Dictionary;
 import java.util.Hashtable;
+
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
@@ -50,7 +52,7 @@ public class DefaultDistributionEventFactory implements DistributionEventFactory
     }
 
     public void generatePackageEvent(@NotNull String distributionEventTopic, @NotNull DistributionComponentKind kind,
-                                     @NotNull String name, @NotNull DistributionPackageInfo info) {
+                                     @NotNull String name, @NotNull DistributionPackageInfo info, Calendar queueItemCreationTime) {
         try {
             Dictionary<String, Object> dictionary = new Hashtable<String, Object>();
             dictionary.put(DistributionEventProperties.DISTRIBUTION_COMPONENT_NAME, name);
@@ -60,6 +62,10 @@ public class DefaultDistributionEventFactory implements DistributionEventFactory
             }
             if (info.getPaths() != null) {
                 dictionary.put(DistributionEventProperties.DISTRIBUTION_PATHS, info.getPaths());
+            }
+            
+            if(null != queueItemCreationTime) {
+                dictionary.put(DistributionEventProperties.DISTRIBUTION_ENQUEUE_TIMESTAMP, queueItemCreationTime.getTimeInMillis());
             }
             generateEvent(distributionEventTopic, dictionary);
 

--- a/src/main/java/org/apache/sling/distribution/event/impl/DistributionEventFactory.java
+++ b/src/main/java/org/apache/sling/distribution/event/impl/DistributionEventFactory.java
@@ -19,7 +19,7 @@
 package org.apache.sling.distribution.event.impl;
 
 import java.util.Calendar;
-
+import java.util.Optional;
 import org.apache.sling.distribution.component.impl.DistributionComponentKind;
 import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +35,6 @@ public interface DistributionEventFactory {
      * @param distributionEventType the type of event to be generated
      */
     void generatePackageEvent(@NotNull String distributionEventType, @NotNull DistributionComponentKind kind,
-                              @NotNull String name, @NotNull DistributionPackageInfo info, Calendar queueItemCreationTime);
+                              @NotNull String name, @NotNull DistributionPackageInfo info, Optional<Calendar> queueItemCreationTime);
 
 }

--- a/src/main/java/org/apache/sling/distribution/event/impl/DistributionEventFactory.java
+++ b/src/main/java/org/apache/sling/distribution/event/impl/DistributionEventFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.sling.distribution.event.impl;
 
+import java.util.Calendar;
+
 import org.apache.sling.distribution.component.impl.DistributionComponentKind;
 import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +35,6 @@ public interface DistributionEventFactory {
      * @param distributionEventType the type of event to be generated
      */
     void generatePackageEvent(@NotNull String distributionEventType, @NotNull DistributionComponentKind kind,
-                              @NotNull String name, @NotNull DistributionPackageInfo info);
+                              @NotNull String name, @NotNull DistributionPackageInfo info, Calendar queueItemCreationTime);
 
 }

--- a/src/main/java/org/apache/sling/distribution/event/impl/DistributionEventFactory.java
+++ b/src/main/java/org/apache/sling/distribution/event/impl/DistributionEventFactory.java
@@ -19,7 +19,6 @@
 package org.apache.sling.distribution.event.impl;
 
 import java.util.Calendar;
-import java.util.Optional;
 import org.apache.sling.distribution.component.impl.DistributionComponentKind;
 import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.jetbrains.annotations.NotNull;
@@ -35,6 +34,6 @@ public interface DistributionEventFactory {
      * @param distributionEventType the type of event to be generated
      */
     void generatePackageEvent(@NotNull String distributionEventType, @NotNull DistributionComponentKind kind,
-                              @NotNull String name, @NotNull DistributionPackageInfo info, Optional<Calendar> queueItemCreationTime);
+                              @NotNull String name, @NotNull DistributionPackageInfo info, Calendar queueItemCreationTime);
 
 }

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
@@ -79,7 +79,8 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
             log.warn("could not install distribution package {}", distributionPackage.getId());
         }
 
-        eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER, name, distributionPackage.getInfo());
+        eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER,
+                name, distributionPackage.getInfo(), null);
     }
 
     @Override
@@ -105,7 +106,8 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
                         if (packageBuilder.installPackage(resourceResolver, distributionPackage)) {
                             DistributionPackageInfo info = distributionPackage.getInfo();
                             log.info("package installed {}", info);
-                            eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER, name, info);
+                            eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED,
+                                    DistributionComponentKind.IMPORTER, name, info, null);
                             return info;
                         } else {
                             throw new DistributionException("could not install package {}" + distributionPackage);
@@ -134,13 +136,15 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
                     packageInfo = packageBuilder.installPackage(resourceResolver, stream);
                     log.info("package installed {}", packageInfo);
                 }
-                eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER, name, packageInfo);
+                eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER,
+                        name, packageInfo, null);
                 return packageInfo;
             }
         } else {
             DistributionPackageInfo packageInfo = packageBuilder.installPackage(resourceResolver, stream);
             log.info("package installed");
-            eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER, name, packageInfo);
+            eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED,
+                    DistributionComponentKind.IMPORTER, name, packageInfo, null);
             return packageInfo;
         }
 

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.distribution.common.DistributionException;
 import org.apache.sling.distribution.component.impl.DistributionComponentKind;
@@ -80,7 +82,7 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
         }
 
         eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER,
-                name, distributionPackage.getInfo(), null);
+                name, distributionPackage.getInfo(), Optional.empty());
     }
 
     @Override
@@ -107,7 +109,7 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
                             DistributionPackageInfo info = distributionPackage.getInfo();
                             log.info("package installed {}", info);
                             eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED,
-                                    DistributionComponentKind.IMPORTER, name, info, null);
+                                    DistributionComponentKind.IMPORTER, name, info, Optional.empty());
                             return info;
                         } else {
                             throw new DistributionException("could not install package {}" + distributionPackage);

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporter.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.distribution.common.DistributionException;
@@ -32,8 +31,8 @@ import org.apache.sling.distribution.event.DistributionEventTopics;
 import org.apache.sling.distribution.event.impl.DistributionEventFactory;
 import org.apache.sling.distribution.packaging.DistributionPackage;
 import org.apache.sling.distribution.packaging.DistributionPackageBuilder;
-import org.apache.sling.distribution.packaging.impl.DistributionPackageImporter;
 import org.apache.sling.distribution.packaging.DistributionPackageInfo;
+import org.apache.sling.distribution.packaging.impl.DistributionPackageImporter;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageUtils;
 import org.apache.sling.distribution.packaging.impl.ReferencePackage;
 import org.jetbrains.annotations.NotNull;
@@ -82,7 +81,7 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
         }
 
         eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED, DistributionComponentKind.IMPORTER,
-                name, distributionPackage.getInfo(), Optional.empty());
+                name, distributionPackage.getInfo(), null);
     }
 
     @Override
@@ -109,7 +108,7 @@ public class LocalDistributionPackageImporter implements DistributionPackageImpo
                             DistributionPackageInfo info = distributionPackage.getInfo();
                             log.info("package installed {}", info);
                             eventFactory.generatePackageEvent(DistributionEventTopics.IMPORTER_PACKAGE_IMPORTED,
-                                    DistributionComponentKind.IMPORTER, name, info, Optional.empty());
+                                    DistributionComponentKind.IMPORTER, name, info, null);
                             return info;
                         } else {
                             throw new DistributionException("could not install package {}" + distributionPackage);

--- a/src/test/java/org/apache/sling/distribution/trigger/impl/DistributionEventDistributeDistributionTriggerTest.java
+++ b/src/test/java/org/apache/sling/distribution/trigger/impl/DistributionEventDistributeDistributionTriggerTest.java
@@ -98,7 +98,7 @@ public class DistributionEventDistributeDistributionTriggerTest {
             public void handle(ResourceResolver resourceResolver, DistributionRequest request) {
                 // we simple fire an event, to cause the loop
                 eventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED,
-                        DistributionComponentKind.AGENT, "test", info);
+                        DistributionComponentKind.AGENT, "test", info, null);
                 handled.addAndGet(1);
             }
         };
@@ -108,7 +108,7 @@ public class DistributionEventDistributeDistributionTriggerTest {
         Thread testExecution = new Thread() {
             @Override public void run() {
                 eventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED, DistributionComponentKind.AGENT,
-                        "origin", info);
+                        "origin", info, null);
             }
         };
 

--- a/src/test/java/org/apache/sling/distribution/trigger/impl/DistributionEventDistributeDistributionTriggerTest.java
+++ b/src/test/java/org/apache/sling/distribution/trigger/impl/DistributionEventDistributeDistributionTriggerTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -98,7 +99,7 @@ public class DistributionEventDistributeDistributionTriggerTest {
             public void handle(ResourceResolver resourceResolver, DistributionRequest request) {
                 // we simple fire an event, to cause the loop
                 eventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED,
-                        DistributionComponentKind.AGENT, "test", info, null);
+                        DistributionComponentKind.AGENT, "test", info, Optional.empty());
                 handled.addAndGet(1);
             }
         };
@@ -108,7 +109,7 @@ public class DistributionEventDistributeDistributionTriggerTest {
         Thread testExecution = new Thread() {
             @Override public void run() {
                 eventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED, DistributionComponentKind.AGENT,
-                        "origin", info, null);
+                        "origin", info, Optional.empty());
             }
         };
 

--- a/src/test/java/org/apache/sling/distribution/trigger/impl/DistributionEventDistributeDistributionTriggerTest.java
+++ b/src/test/java/org/apache/sling/distribution/trigger/impl/DistributionEventDistributeDistributionTriggerTest.java
@@ -18,6 +18,13 @@
  */
 package org.apache.sling.distribution.trigger.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.DistributionRequestType;
@@ -31,14 +38,6 @@ import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.BundleContext;
-
-import static org.mockito.Mockito.mock;
-import static org.junit.Assert.*;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Testcase for {@link DistributionEventDistributeDistributionTrigger}
@@ -99,7 +98,7 @@ public class DistributionEventDistributeDistributionTriggerTest {
             public void handle(ResourceResolver resourceResolver, DistributionRequest request) {
                 // we simple fire an event, to cause the loop
                 eventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED,
-                        DistributionComponentKind.AGENT, "test", info, Optional.empty());
+                        DistributionComponentKind.AGENT, "test", info, null);
                 handled.addAndGet(1);
             }
         };
@@ -109,7 +108,7 @@ public class DistributionEventDistributeDistributionTriggerTest {
         Thread testExecution = new Thread() {
             @Override public void run() {
                 eventFactory.generatePackageEvent(DistributionEventTopics.AGENT_PACKAGE_DISTRIBUTED, DistributionComponentKind.AGENT,
-                        "origin", info, Optional.empty());
+                        "origin", info, null);
             }
         };
 


### PR DESCRIPTION
- Improvement aims at adding the queue item creation time, essentially when the the item was creation for the first time, and enqueue into the queue.
- The purpose to get this detail is to be able to capture metrics at the consumer level. The consumers could have an event handler, which can capture the duration which turns out to be (NOW MINUS queue item creation time thrown in the distribution event package); NOW being the current time in the event handler (consumer).