### PR TITLE
SLING-9873-A comma in node name cause Sling Content Distribution to fail

### DIFF
--- a/src/main/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackage.java
@@ -40,7 +40,7 @@ public class SimpleDistributionPackage extends AbstractDistributionPackage imple
 
     private final static String PACKAGE_START = "DSTRPCK:";
     private final static String DELIM = "|";
-    private final static String PATH_DELIM = ",";
+    private final static String PATH_DELIM = ":";
     private final long size;
 
     public SimpleDistributionPackage(DistributionRequest request, String type) {

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackage.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackage.java
@@ -38,9 +38,11 @@ public class SimpleDistributionPackage extends AbstractDistributionPackage imple
 
     private static final Logger log = LoggerFactory.getLogger(SimpleDistributionPackage.class);
 
-    private final static String PACKAGE_START = "DSTRPCK:";
+    private final static String PACKAGE_START = "DSTRPCK::";
+    private final static String PACKAGE_START_OLD = "DSTRPCK:";
     private final static String DELIM = "|";
     private final static String PATH_DELIM = ":";
+    private final static String PATH_DELIM_OLD = ",";
     private final long size;
 
     public SimpleDistributionPackage(DistributionRequest request, String type) {
@@ -78,12 +80,15 @@ public class SimpleDistributionPackage extends AbstractDistributionPackage imple
         return b.toString();
     }
 
-    public static SimpleDistributionPackage fromIdString(String id, String type) {
-        if (!id.startsWith(PACKAGE_START)) {
+    public static SimpleDistributionPackage fromIdString(String packageId, String type) {
+        String id = null;
+        if (packageId.startsWith(PACKAGE_START)) {
+            id = packageId.substring(PACKAGE_START.length());
+        } else if (packageId.startsWith(PACKAGE_START_OLD)) { //For back compatibility with old path delimiter.
+            id = packageId.substring(PACKAGE_START_OLD.length());
+        } else {
             return null;
         }
-
-        id = id.substring(PACKAGE_START.length());
 
         String[] parts = id.split(Pattern.quote(DELIM));
 
@@ -98,7 +103,16 @@ public class SimpleDistributionPackage extends AbstractDistributionPackage imple
 
         SimpleDistributionPackage distributionPackage = null;
         if (distributionRequestType != null) {
-            String[] paths = pathsString == null ? new String[0] : pathsString.split(PATH_DELIM);
+            String[] paths = null;
+            if (pathsString != null) {
+                if (packageId.startsWith(PACKAGE_START)) {
+                    paths = pathsString.split(PATH_DELIM);
+                } else {
+                    paths = pathsString.split(PATH_DELIM_OLD); //For back compatibility with old path delimiter
+                }
+            } else {
+                paths = new String[0];
+            }
 
             DistributionRequest request = new SimpleDistributionRequest(distributionRequestType, paths);
             distributionPackage = new SimpleDistributionPackage(request, type);

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackageTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackageTest.java
@@ -44,8 +44,8 @@ import static org.mockito.Mockito.when;
  */
 public class SimpleDistributionPackageTest {
 
-    private static final String DSTRPCK_DELETE = "DSTRPCK:DELETE|/abc:/c";
-    private static final String DSTRPCK_ITEM_WITH_COMMA_DELETE = "DSTRPCK:DELETE|/ab,c:/c";
+    private static final String DSTRPCK_DELETE = "DSTRPCK::DELETE|/abc:/c";
+    private static final String DSTRPCK_ITEM_WITH_COMMA_DELETE = "DSTRPCK::DELETE|/ab,c:/c";
 
     @Test
     public void testInvalid() {
@@ -118,7 +118,7 @@ public class SimpleDistributionPackageTest {
     public void testSimplePackageFromTest() throws Exception {
         DistributionRequest distributionRequest = new SimpleDistributionRequest(DistributionRequestType.TEST);
         SimpleDistributionPackage createdPackage = new SimpleDistributionPackage(distributionRequest, "VOID");
-        SimpleDistributionPackage readPackage = SimpleDistributionPackage.fromStream(new ByteArrayInputStream(("DSTRPCK:TEST|").getBytes()), "VOID");
+        SimpleDistributionPackage readPackage = SimpleDistributionPackage.fromStream(new ByteArrayInputStream(("DSTRPCK::TEST|").getBytes()), "VOID");
         assertNotNull(readPackage);
         assertEquals(createdPackage.getType(), readPackage.getType());
         assertEquals(createdPackage.getInfo().getRequestType(), readPackage.getInfo().getRequestType());

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackageTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/SimpleDistributionPackageTest.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.DistributionRequestType;
 import org.apache.sling.distribution.SimpleDistributionRequest;
-import org.apache.sling.distribution.packaging.impl.SimpleDistributionPackage;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -45,7 +44,8 @@ import static org.mockito.Mockito.when;
  */
 public class SimpleDistributionPackageTest {
 
-    private static final String DSTRPCK_DELETE = "DSTRPCK:DELETE|/abc,/c";
+    private static final String DSTRPCK_DELETE = "DSTRPCK:DELETE|/abc:/c";
+    private static final String DSTRPCK_ITEM_WITH_COMMA_DELETE = "DSTRPCK:DELETE|/ab,c:/c";
 
     @Test
     public void testInvalid() {
@@ -74,6 +74,22 @@ public class SimpleDistributionPackageTest {
         when(stream.read(Mockito.any(byte[].class), Mockito.eq(0), Mockito.anyInt())).thenThrow(new IOException("Expected"));
         SimpleDistributionPackage pkg = SimpleDistributionPackage.fromStream(stream, "ADD");
         assertThat(pkg, nullValue());
+    }
+
+    @Test
+    public void testCreatedAndReadPackagesEqualityWithCommaInName() throws Exception {
+        DistributionRequest request = new SimpleDistributionRequest(DistributionRequestType.DELETE, "/ab,c", "/c");
+        SimpleDistributionPackage createdPackage = new SimpleDistributionPackage(request, "VOID");
+        assertThat(createdPackage.toString(), equalTo(DSTRPCK_ITEM_WITH_COMMA_DELETE));
+        // Just to run the code
+        createdPackage.acquire();
+        createdPackage.release();
+        createdPackage.close();
+        createdPackage.delete();
+
+        SimpleDistributionPackage readPackage = SimpleDistributionPackage.fromStream(new ByteArrayInputStream(DSTRPCK_ITEM_WITH_COMMA_DELETE.getBytes()), "VOID");
+        assertNotNull(readPackage);
+        assertEquals(Arrays.toString(createdPackage.getInfo().getPaths()), Arrays.toString(readPackage.getInfo().getPaths()));
     }
     
     @Test


### PR DESCRIPTION
1. Providing a test case to show the behavior.
2. Changing the path delimiter to colon (:) because that's a jcr invalid character and hence no danger of anyone using it in a node name.
3. Removing unused import from test file.