### PR TITLE
SLING-10602 DistributionQueueItem's path should be correctly logged in case of success and failure

### DIFF
--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -92,7 +92,7 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
 
             final long endTime = System.currentTimeMillis();
 
-            distributionLog.debug("[{}] ITEM-PROCESSED item={}, status={}, processingTime={}ms", queueName, queueItem, success, endTime - startTime);
+            distributionLog.info("[{}] ITEM-PROCESSED item={}, status={}, processingTime={}ms", queueName, queueItem, success, endTime - startTime);
 
             return success;
 

--- a/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
+++ b/src/main/java/org/apache/sling/distribution/agent/impl/SimpleDistributionAgentQueueProcessor.java
@@ -92,7 +92,7 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
 
             final long endTime = System.currentTimeMillis();
 
-            distributionLog.info("[{}] ITEM-PROCESSED item={}, status={}, processingTime={}ms", queueName, queueItem, success, endTime - startTime);
+            distributionLog.debug("[{}] ITEM-PROCESSED item={}, status={}, processingTime={}ms", queueName, queueItem, success, endTime - startTime);
 
             return success;
 
@@ -147,8 +147,8 @@ class SimpleDistributionAgentQueueProcessor implements DistributionQueueProcesso
                     removeItemFromQueue = true;
                     final long endTime = System.currentTimeMillis();
 
-                    distributionLog.info("[{}] PACKAGE-DELIVERED {}: {} paths={}, importTime={}ms, execTime={}ms, size={}B", queueName, requestId,
-                            requestType, paths,
+                    distributionLog.info("[{}] PACKAGE-DELIVERED {}: {} item={}, paths={}, importTime={}ms, execTime={}ms, size={}B", queueName, requestId,
+                            requestType, queueEntry.getItem().getPackageId(), paths,
                             endTime - startTime, endTime - globalStartTime,
                             packageSize);
                 } catch (RecoverableDistributionException e) {

--- a/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
+++ b/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
@@ -37,7 +37,6 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
 
     private final String packageId;
     private final long size;
-    private final Map<String, Object> base;
 
     public DistributionQueueItem(@NotNull String packageId, Map<String, Object> base) {
         this(packageId, -1, base);
@@ -47,7 +46,6 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
         super(base);
         this.packageId = packageId;
         this.size = size;
-        this.base = base;
     }
 
     @NotNull
@@ -67,25 +65,25 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
     public String toString() {
         return "DistributionQueueItem{" +
                 "id='" + packageId + '\'' +
-                ", info={" + queueInfo(base) + '}' +
+                ", info={" + queueInfo() + '}' +
                 '}';
     }
 
     /*
      * convert the map of object values into string form
      */
-    private String queueInfo(Map<String, Object> base) {
-        String queueItem = "";
-        for(String key : base.keySet()) {
-            Object value = base.get(key);
+    private String queueInfo() {
+        String queueItemStr = "";
+        for(String key : super.keySet()) {
+            Object value = super.get(key);
             String valueString = "";
-            if (value instanceof String[]) {
-                valueString = key + "=" + Arrays.toString((String[])value);
+            if (value.getClass().isArray()) {
+                valueString = key + "=" + Arrays.toString((Object[])value);
             } else {
                 valueString = key + "=" + value.toString();
             }
-            queueItem = String.join(",", queueItem, valueString);
+            queueItemStr = String.join(",", queueItemStr, valueString);
         }
-        return queueItem.isEmpty() ? queueItem : queueItem.substring(1);
+        return queueItemStr.isEmpty() ? queueItemStr : queueItemStr.substring(1);
     }
 }

--- a/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
+++ b/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
@@ -18,10 +18,12 @@
  */
 package org.apache.sling.distribution.queue;
 
+import java.util.Arrays;
 import java.util.Map;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.distribution.packaging.DistributionPackage;
+import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.queue.spi.DistributionQueue;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,7 +46,6 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
         super(base);
         this.packageId = packageId;
         this.size = size;
-
     }
 
     @NotNull
@@ -60,10 +61,20 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
         return size;
     }
 
+    /**
+     * get the paths covered by the distribution package proxied by this distribution item
+     *
+     * @return an array of paths
+     */
+    private String[] getPaths() {
+        return get(DistributionPackageInfo.PROPERTY_REQUEST_PATHS, String[].class);
+    }
+
     @Override
     public String toString() {
         return "DistributionQueueItem{" +
                 "id='" + packageId + '\'' +
+                ", paths='" + Arrays.toString(getPaths()) + '\'' +
                 ", info=" + super.toString() +
                 '}';
     }

--- a/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
+++ b/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
@@ -62,7 +62,7 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
     }
 
     /**
-     * get the paths covered by the distribution package proxied by this distribution item
+     * get the paths covered by the distribution package proxied by this queue item
      *
      * @return an array of paths
      */

--- a/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
+++ b/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
@@ -65,14 +65,14 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
     public String toString() {
         return "DistributionQueueItem{" +
                 "id='" + packageId + '\'' +
-                ", info={" + queueInfo() + '}' +
+                ", info={" + getQueueInfo() + '}' +
                 '}';
     }
 
     /*
      * convert the map of object values into string form
      */
-    private String queueInfo() {
+    private String getQueueInfo() {
         String queueItemStr = "";
         for(String key : super.keySet()) {
             Object value = super.get(key);

--- a/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
+++ b/src/main/java/org/apache/sling/distribution/queue/DistributionQueueItem.java
@@ -20,10 +20,10 @@ package org.apache.sling.distribution.queue;
 
 import java.util.Arrays;
 import java.util.Map;
+
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.distribution.packaging.DistributionPackage;
-import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.queue.spi.DistributionQueue;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,6 +37,7 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
 
     private final String packageId;
     private final long size;
+    private final Map<String, Object> base;
 
     public DistributionQueueItem(@NotNull String packageId, Map<String, Object> base) {
         this(packageId, -1, base);
@@ -46,6 +47,7 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
         super(base);
         this.packageId = packageId;
         this.size = size;
+        this.base = base;
     }
 
     @NotNull
@@ -61,21 +63,29 @@ public final class DistributionQueueItem extends ValueMapDecorator implements Va
         return size;
     }
 
-    /**
-     * get the paths covered by the distribution package proxied by this queue item
-     *
-     * @return an array of paths
-     */
-    private String[] getPaths() {
-        return get(DistributionPackageInfo.PROPERTY_REQUEST_PATHS, String[].class);
-    }
-
     @Override
     public String toString() {
         return "DistributionQueueItem{" +
                 "id='" + packageId + '\'' +
-                ", paths='" + Arrays.toString(getPaths()) + '\'' +
-                ", info=" + super.toString() +
+                ", info={" + queueInfo(base) + '}' +
                 '}';
+    }
+
+    /*
+     * convert the map of object values into string form
+     */
+    private String queueInfo(Map<String, Object> base) {
+        String queueItem = "";
+        for(String key : base.keySet()) {
+            Object value = base.get(key);
+            String valueString = "";
+            if (value instanceof String[]) {
+                valueString = key + "=" + Arrays.toString((String[])value);
+            } else {
+                valueString = key + "=" + value.toString();
+            }
+            queueItem = String.join(",", queueItem, valueString);
+        }
+        return queueItem.isEmpty() ? queueItem : queueItem.substring(1);
     }
 }


### PR DESCRIPTION
Adding the path(s) for which distribution package was created in the logging for distribution queue item. Also changing the debug level log to info level to give admin more info about which resources were distributed and how much time it took for distribution to complete.