### PR TITLE
SLING-11150: Return package id in the DistributionResponse for a dete…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.distribution.api</artifactId>
-            <version>0.5.1-SNAPSHOT</version>
+            <version>0.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.distribution.api</artifactId>
-            <version>0.4.0</version>
+            <version>0.5.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/src/main/java/org/apache/sling/distribution/impl/CompositeDistributionResponse.java
+++ b/src/main/java/org/apache/sling/distribution/impl/CompositeDistributionResponse.java
@@ -22,6 +22,9 @@ package org.apache.sling.distribution.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.annotation.Nonnull;
+
 import org.apache.sling.distribution.DistributionRequestState;
 import org.apache.sling.distribution.DistributionResponse;
 import org.apache.sling.distribution.DistributionResponseInfo;
@@ -92,6 +95,7 @@ public class CompositeDistributionResponse extends SimpleDistributionResponse {
         return message;
     }
 
+    @Nonnull
     @Override
     public DistributionResponseInfo getDistributionInfo() {
         return info;

--- a/src/main/java/org/apache/sling/distribution/impl/SimpleDistributionResponse.java
+++ b/src/main/java/org/apache/sling/distribution/impl/SimpleDistributionResponse.java
@@ -21,7 +21,10 @@ package org.apache.sling.distribution.impl;
 
 import org.apache.sling.distribution.DistributionRequestState;
 import org.apache.sling.distribution.DistributionResponse;
+import org.apache.sling.distribution.DistributionResponseInfo;
 import org.jetbrains.annotations.NotNull;
+
+import static org.apache.sling.distribution.DistributionResponseInfo.NONE;
 
 /**
  * Simple implementation of {@link DistributionResponse} where success is given by not being in FAILED state.
@@ -31,13 +34,21 @@ public class SimpleDistributionResponse implements DistributionResponse {
 
     private final DistributionRequestState state;
     private final String message;
+    private final DistributionResponseInfo info;
 
-    public SimpleDistributionResponse(DistributionRequestState state, String message) {
-
+    public SimpleDistributionResponse(DistributionRequestState state, String message, DistributionResponseInfo info) {
         this.state = state;
         this.message = message;
+        if (info == null) {
+            info = NONE;
+        }
+        this.info = info;
     }
-
+    
+    public SimpleDistributionResponse(DistributionRequestState state, String message) {
+        this(state, message, NONE);
+    }
+    
     public boolean isSuccessful() {
         return DistributionRequestState.ACCEPTED.equals(state) || DistributionRequestState.DISTRIBUTED.equals(state);
     }
@@ -52,11 +63,17 @@ public class SimpleDistributionResponse implements DistributionResponse {
     }
 
     @Override
+    public DistributionResponseInfo getDistributionInfo() {
+        return info;
+    }
+    
+    @Override
     public String toString() {
-        return "CompositeDistributionResponse{" +
-                "isSuccesful=" + isSuccessful() +
+        return "SimpleDistributionResponse{" +
+                "isSuccessful=" + isSuccessful() +
                 ", state=" + state +
                 ", message=" + message +
+                ", info={id=" + info.getId() + "}" + 
                 '}';
     }
 

--- a/src/main/java/org/apache/sling/distribution/impl/SimpleDistributionResponse.java
+++ b/src/main/java/org/apache/sling/distribution/impl/SimpleDistributionResponse.java
@@ -19,6 +19,8 @@
 
 package org.apache.sling.distribution.impl;
 
+import javax.annotation.Nonnull;
+
 import org.apache.sling.distribution.DistributionRequestState;
 import org.apache.sling.distribution.DistributionResponse;
 import org.apache.sling.distribution.DistributionResponseInfo;
@@ -62,6 +64,7 @@ public class SimpleDistributionResponse implements DistributionResponse {
         return message;
     }
 
+    @Nonnull
     @Override
     public DistributionResponseInfo getDistributionInfo() {
         return info;

--- a/src/main/java/org/apache/sling/distribution/resources/impl/ExtendedDistributionServiceResourceProvider.java
+++ b/src/main/java/org/apache/sling/distribution/resources/impl/ExtendedDistributionServiceResourceProvider.java
@@ -202,6 +202,7 @@ public class ExtendedDistributionServiceResourceProvider extends DistributionSer
             DistributionPackageInfo packageInfo = DistributionPackageUtils.fromQueueItem(item);
 
             result.put("id", entry.getId());
+            result.put("pkgId", item.getPackageId());
             result.put("size", item.getSize());
             result.put("paths", packageInfo.getPaths());
             result.put("action", packageInfo.getRequestType());

--- a/src/test/java/org/apache/sling/distribution/impl/DistributionResponseTest.java
+++ b/src/test/java/org/apache/sling/distribution/impl/DistributionResponseTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.distribution.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sling.distribution.DistributionRequestState;
+import org.apache.sling.distribution.DistributionResponse;
+import org.apache.sling.distribution.DistributionResponseInfo;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class DistributionResponseTest {
+    @Test
+    public void nullDistributionResponse() {
+        DistributionResponse res1 = new SimpleDistributionResponse(DistributionRequestState.DISTRIBUTED, "success", null);
+
+        assertNotNull(res1.getDistributionInfo());
+        assertEquals("", res1.getDistributionInfo().getId());
+
+        DistributionResponse res2 = new SimpleDistributionResponse(DistributionRequestState.ACCEPTED, "success", null);
+        List<DistributionResponse> responses = new ArrayList<>();
+        responses.add(res1);
+        responses.add(res2);
+        CompositeDistributionResponse compositeResponse = new CompositeDistributionResponse(responses, 2, 0, 0);
+        assertNotNull(compositeResponse.getDistributionInfo());
+        assertEquals(list("", "").toString(), compositeResponse.getDistributionInfo().getId());
+    }
+    
+    @Test
+    public void emptyDistributionResponse() {
+        DistributionResponse res1 = new SimpleDistributionResponse(DistributionRequestState.DISTRIBUTED, "success");
+
+        assertNotNull(res1.getDistributionInfo());
+        assertEquals("", res1.getDistributionInfo().getId());
+        
+        DistributionResponse res2 = new SimpleDistributionResponse(DistributionRequestState.ACCEPTED, "success");
+        List<DistributionResponse> responses = new ArrayList<>();
+        responses.add(res1);
+        responses.add(res2);
+        CompositeDistributionResponse compositeResponse = new CompositeDistributionResponse(responses, 2, 0, 0);
+        assertNotNull(compositeResponse.getDistributionInfo());
+        assertEquals(list("", "").toString(), compositeResponse.getDistributionInfo().getId());
+    }
+
+    @Test
+    public void nonEmptyDistributionResponse() {
+        DistributionResponse res1 = new SimpleDistributionResponse(DistributionRequestState.DISTRIBUTED, "success", 
+            new DistributionResponseInfo() {
+                @NotNull @Override public String getId() {
+                    return "res1";
+                }
+        });
+
+        assertNotNull(res1.getDistributionInfo());
+        assertEquals("res1", res1.getDistributionInfo().getId());
+
+        DistributionResponse res2 = new SimpleDistributionResponse(DistributionRequestState.ACCEPTED, "success",
+            new DistributionResponseInfo() {
+                @NotNull @Override public String getId() {
+                    return "res2";
+                }
+            });
+        List<DistributionResponse> responses = new ArrayList<>();
+        responses.add(res1);
+        responses.add(res2);
+        CompositeDistributionResponse compositeResponse = new CompositeDistributionResponse(responses, 2, 0, 0);
+        assertNotNull(compositeResponse.getDistributionInfo());
+        assertEquals(list("res1", "res2").toString(), compositeResponse.getDistributionInfo().getId());
+    }
+    
+    private List<String> list(String str1, String str2) {
+        List<String> expectedIds = new ArrayList<>();
+        expectedIds.add(str1);
+        expectedIds.add(str2);
+        return expectedIds;
+    }
+}


### PR DESCRIPTION
…rministic way of identifying status

- Add DistributionResponseInfo object to implementations of DistributionResponse
- Add package id in the item properties returned from the queue resource provider