### PR TITLE
SLING-11366: Provide more exception error context on the JSON API responses

### DIFF
--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionAgentServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionAgentServlet.java
@@ -72,12 +72,8 @@ public class DistributionAgentServlet extends SlingAllMethodsServlet {
 
                 log.debug("distribution response : {}", distributionResponse);
             } catch (Throwable e) {
-                String msg = "an unexpected error has occurred";
-                Map<String, String> metadata = new HashMap<String, String>();
-                metadata.put("details", e.getMessage());
-
-                log.error(msg, e);
-                ServletJsonUtils.writeJson(response, 503, msg, metadata);
+                log.error("an unexpected error has occurred", e);
+                ServletJsonUtils.writeJson(response, 503, e.getMessage(), null);
             }
         } else {
             ServletJsonUtils.writeJson(response, 404, "agent not found", null);

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionAgentServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionAgentServlet.java
@@ -21,6 +21,8 @@ package org.apache.sling.distribution.servlet;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -70,8 +72,12 @@ public class DistributionAgentServlet extends SlingAllMethodsServlet {
 
                 log.debug("distribution response : {}", distributionResponse);
             } catch (Throwable e) {
-                log.error("an unexpected error has occurred", e);
-                ServletJsonUtils.writeJson(response, 503, "an unexpected error has occurred", null);
+                String msg = "an unexpected error has occurred";
+                Map<String, String> metadata = new HashMap<String, String>();
+                metadata.put("details", e.getMessage());
+
+                log.error(msg, e);
+                ServletJsonUtils.writeJson(response, 503, msg, metadata);
             }
         } else {
             ServletJsonUtils.writeJson(response, 404, "agent not found", null);

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.distribution.servlet;
 
+import static java.lang.String.format;
 import static javax.servlet.http.HttpServletResponse.*;
 import static org.apache.sling.distribution.util.impl.DigestUtils.openDigestInputStream;
 import static org.apache.sling.distribution.util.impl.DigestUtils.readDigestMessage;
@@ -126,12 +127,10 @@ public class DistributionPackageImporterServlet extends SlingAllMethodsServlet {
             ServletJsonUtils.writeJson(response, SC_OK, "package imported successfully", null);
 
         } catch (final Throwable e) {
-            String msg = "an unexpected error has occurred during distribution import";
-            Map<String, String> metadata = new HashMap<String, String>();
-            metadata.put("details", e.getMessage());
-
+            String msg = format("an unexpected error has occurred during distribution import. Error:%s",
+                    e.getMessage());
             log.error(msg, e);
-            ServletJsonUtils.writeJson(response, SC_INTERNAL_SERVER_ERROR, msg, metadata);
+            ServletJsonUtils.writeJson(response, SC_INTERNAL_SERVER_ERROR, msg, null);
         } finally {
             long end = System.currentTimeMillis();
             log.debug("Processed package import request in {} ms", end - start);

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
@@ -127,7 +127,8 @@ public class DistributionPackageImporterServlet extends SlingAllMethodsServlet {
             ServletJsonUtils.writeJson(response, SC_OK, "package imported successfully", null);
 
         } catch (final Throwable e) {
-            String msg = format("an unexpected error has occurred during distribution import. Error:%s",
+            String msg = format("an unexpected error has occurred during distribution import. " +
+                            "Error: %s",
                     e.getMessage());
             log.error(msg, e);
             ServletJsonUtils.writeJson(response, SC_INTERNAL_SERVER_ERROR, msg, null);

--- a/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
+++ b/src/main/java/org/apache/sling/distribution/servlet/DistributionPackageImporterServlet.java
@@ -112,7 +112,7 @@ public class DistributionPackageImporterServlet extends SlingAllMethodsServlet {
                 String receivedDigestMessage = readDigestMessage((DigestInputStream) stream);
                 if (!digestMessage.equalsIgnoreCase(receivedDigestMessage)) {
                     log.error("Error during distribution import: received distribution package is corrupted, expected [{}] but received [{}]",
-                              digestMessage, receivedDigestMessage);
+                            digestMessage, receivedDigestMessage);
                     Map<String, String> kv = new HashMap<String, String>();
                     kv.put("digestAlgorithm", digestAlgorithm);
                     kv.put("expected", digestMessage);
@@ -126,8 +126,12 @@ public class DistributionPackageImporterServlet extends SlingAllMethodsServlet {
             ServletJsonUtils.writeJson(response, SC_OK, "package imported successfully", null);
 
         } catch (final Throwable e) {
-            ServletJsonUtils.writeJson(response, SC_INTERNAL_SERVER_ERROR, "an unexpected error has occurred during distribution import", null);
-            log.error("Error during distribution import", e);
+            String msg = "an unexpected error has occurred during distribution import";
+            Map<String, String> metadata = new HashMap<String, String>();
+            metadata.put("details", e.getMessage());
+
+            log.error(msg, e);
+            ServletJsonUtils.writeJson(response, SC_INTERNAL_SERVER_ERROR, msg, metadata);
         } finally {
             long end = System.currentTimeMillis();
             log.debug("Processed package import request in {} ms", end - start);


### PR DESCRIPTION
The API is currently responding with a very generic message when packages fail to be distributed.

```
{
  "message": "an unexpected error has occurred"
}

```

This should be improved since there are some errors that are due to bad usage, eg: packages that are too big, and we should to provide more context to the client:

```
{
  "message": "an unexpected error has occurred",
  "details": "Failed to create content package for requestType=ADD, paths=[/content]. Error=Can't distribute package with size greater than 1 Byte, actual 4053"
}

```