### PR TITLE
Implement external error codes for easier exception data propagation and tracing

### DIFF
--- a/src/main/java/org/apache/sling/distribution/common/DistributionException.java
+++ b/src/main/java/org/apache/sling/distribution/common/DistributionException.java
@@ -18,8 +18,6 @@
  */
 package org.apache.sling.distribution.common;
 
-import org.apache.sling.distribution.common.error.ErrorCode;
-
 /**
  * Generic checked exception for distribution
  */

--- a/src/main/java/org/apache/sling/distribution/common/DistributionException.java
+++ b/src/main/java/org/apache/sling/distribution/common/DistributionException.java
@@ -18,21 +18,35 @@
  */
 package org.apache.sling.distribution.common;
 
+import org.apache.sling.distribution.common.error.ErrorCode;
+
 /**
  * Generic checked exception for distribution
  */
 @SuppressWarnings("serial")
-public class DistributionException extends Exception {
+public class DistributionException extends DocumentedException {
 
     public DistributionException(Throwable e) {
         super(e);
+    }
+
+    public DistributionException(Throwable e, ErrorCode errorCode) {
+        super(e, errorCode);
     }
 
     public DistributionException(String string) {
         super(string);
     }
 
+    public DistributionException(String string, ErrorCode errorCode) {
+        super(string, errorCode);
+    }
+
     public DistributionException(String string, Throwable cause) {
         super(string, cause);
+    }
+
+    public DistributionException(String string, Throwable cause, ErrorCode errorCode) {
+        super(string, cause, errorCode);
     }
 }

--- a/src/main/java/org/apache/sling/distribution/common/DocumentedException.java
+++ b/src/main/java/org/apache/sling/distribution/common/DocumentedException.java
@@ -1,7 +1,5 @@
 package org.apache.sling.distribution.common;
 
-import org.apache.sling.distribution.common.error.ErrorCode;
-
 /**
  * A type of exception that contains additional error metadata that link to external
  * documentation and allows for distributed tracing, through specific ERROR_CODES.

--- a/src/main/java/org/apache/sling/distribution/common/DocumentedException.java
+++ b/src/main/java/org/apache/sling/distribution/common/DocumentedException.java
@@ -1,0 +1,49 @@
+package org.apache.sling.distribution.common;
+
+import org.apache.sling.distribution.common.error.ErrorCode;
+
+/**
+ * A type of exception that contains additional error metadata that link to external
+ * documentation and allows for distributed tracing, through specific ERROR_CODES.
+ */
+public class DocumentedException extends Exception {
+    private ErrorCode errorCode;
+
+    public DocumentedException(Throwable e, ErrorCode errorCode) {
+        super(e);
+        this.errorCode = errorCode;
+    }
+
+    public DocumentedException(Throwable e) {
+        super(e);
+        errorCodeNotDefined();
+    }
+
+    public DocumentedException(String string, ErrorCode errorCode) {
+        super(string);
+        this.errorCode = errorCode;
+    }
+
+    public DocumentedException(String string) {
+        super(string);
+        errorCodeNotDefined();
+    }
+
+    public DocumentedException(String string, Throwable cause, ErrorCode errorCode) {
+        super(string, cause);
+        this.errorCode = errorCode;
+    }
+
+    public DocumentedException(String string, Throwable cause) {
+        super(string, cause);
+        errorCodeNotDefined();
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    private void errorCodeNotDefined() {
+        this.errorCode = ErrorCode.UNKNOWN_ERROR;
+    }
+}

--- a/src/main/java/org/apache/sling/distribution/common/DocumentedException.java
+++ b/src/main/java/org/apache/sling/distribution/common/DocumentedException.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.sling.distribution.common;
 
 /**

--- a/src/main/java/org/apache/sling/distribution/common/ErrorCode.java
+++ b/src/main/java/org/apache/sling/distribution/common/ErrorCode.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.sling.distribution.common;
 
 /**

--- a/src/main/java/org/apache/sling/distribution/common/ErrorCode.java
+++ b/src/main/java/org/apache/sling/distribution/common/ErrorCode.java
@@ -1,4 +1,4 @@
-package org.apache.sling.distribution.common.error;
+package org.apache.sling.distribution.common;
 
 /**
  * This class defines specific system error codes which allow for easier propagation of exception

--- a/src/main/java/org/apache/sling/distribution/common/error/ErrorCode.java
+++ b/src/main/java/org/apache/sling/distribution/common/error/ErrorCode.java
@@ -1,0 +1,46 @@
+package org.apache.sling.distribution.common.error;
+
+/**
+ * This class defines specific system error codes which allow for easier propagation of exception
+ * data throughout the system, and act as a single point of change for the documentation code,
+ * description and the HTTP status that an exception should generate.
+ */
+public enum ErrorCode {
+    /**
+     * A generic unexpected error in the system.
+     */
+    UNKNOWN_ERROR("unknown", "An unexpected error has occurred.", 500),
+    /**
+     * Error that happens when the client tries to distribute a package that exceeds the
+     * configured package size limit.
+     */
+    DISTRIBUTION_PACKAGE_SIZE_LIMIT_EXCEEDED("package_limit_exceeded", "Package has exceeded the" +
+            " limit bytes size.", 400);
+
+    private final String code;
+    private final String description;
+    private final int httpStatusCode;
+
+    ErrorCode(String code, String description, int httpStatusCode) {
+        this.code = code;
+        this.description = description;
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    @Override
+    public String toString() {
+        return code + ": " + description;
+    }
+}


### PR DESCRIPTION
This PR adds support for static ERROR_CODES that can be configured in a single place, and allow for:

1. Easier propagation of exception expected outcomes, since the expected description, distributed-tracing error code, and HTTP status come very easily when each exception is thrown, avoiding extensive try/catch scenarios.
2. A single place of change for API error descriptions.
3. This can be extended to add links to external documentation, once the error codes are added there.

### Implementation

Each error code is defined in the `ErrorCodes` enum, and contains:

- A unique `code`, which needs to be unique for all the errors;
- A external-facing `description`;
- An expected `HTTP status code`

### Initial Errors
```java
    UNKNOWN_ERROR("unknown", "An unexpected error has occurred.", 500)
    DISTRIBUTION_PACKAGE_SIZE_LIMIT_EXCEEDED("package_limit_exceeded", "Package has exceeded the limit bytes size.", 400);
```



### Notes

- This will maintain backward compatibility since we still support the exception without error code
- Exception can start implementing error codes simply by extending the `DocumentedException` class
