### PR TITLE
SLING-11560 : Vault error when importing a node with the same name and UUID as a pre-existing non-sibling node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,13 @@
             <artifactId>org.apache.jackrabbit.vault</artifactId>
             <version>3.6.4</version>
         </dependency>
+        <!-- LOMBOK -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.22</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- HTTP -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         <dependency>
             <groupId>org.apache.jackrabbit.vault</groupId>
             <artifactId>org.apache.jackrabbit.vault</artifactId>
-            <version>3.4.0</version>
+            <version>3.6.4</version>
         </dependency>
         <!-- HTTP -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -326,13 +326,6 @@
             <artifactId>org.apache.jackrabbit.vault</artifactId>
             <version>3.6.4</version>
         </dependency>
-        <!-- LOMBOK -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- HTTP -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
@@ -30,12 +30,9 @@ import java.util.UUID;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
-import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.api.RegexpPathMapping;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.config.MetaInf;
-import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.fs.io.Archive;
 import org.apache.jackrabbit.vault.fs.io.ImportOptions;
 import org.apache.jackrabbit.vault.fs.io.Importer;
@@ -72,37 +69,24 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
     private static final String MAPPING_DELIMITER = ";";
 
     private final Packaging packaging;
-    private final ImportMode importMode;
-    private final AccessControlHandling aclHandling;
-    private final AccessControlHandling cugHandling;
     private final String[] packageRoots;
-    private final int autosaveThreshold;
     private final TreeMap<String, List<String>> nodeFilters;
     private final TreeMap<String, List<String>> propertyFilters;
     private final boolean useBinaryReferences;
     private final String name;
     private final Map<String, String> exportPathMapping;
-    private final boolean strict;
-    private final IdConflictPolicy idConflictPolicy;
-    private final boolean overwritePrimaryTypesOfFolders;
+    private final ImportSettings importSettings;
 
-    public FileVaultContentSerializer(String name, Packaging packaging, ImportMode importMode, AccessControlHandling aclHandling, AccessControlHandling cugHandling, String[] packageRoots,
-                                      String[] nodeFilters, String[] propertyFilters, boolean useBinaryReferences, int autosaveThreshold, Map<String, String> exportPathMapping,
-                                      boolean strict, IdConflictPolicy idConflictPolicy, boolean overwritePrimaryTypesOfFolders) {
+    public FileVaultContentSerializer(String name, Packaging packaging, String[] packageRoots, String[] nodeFilters, String[] propertyFilters,
+                                      boolean useBinaryReferences, Map<String, String> exportPathMapping, ImportSettings importSettings) {
         this.name = name;
         this.packaging = packaging;
-        this.importMode = importMode;
-        this.aclHandling = aclHandling;
-        this.cugHandling = cugHandling;
         this.packageRoots = packageRoots;
-        this.autosaveThreshold = autosaveThreshold;
         this.nodeFilters = VltUtils.parseFilters(nodeFilters);
         this.propertyFilters = VltUtils.parseFilters(propertyFilters);
         this.useBinaryReferences = useBinaryReferences;
         this.exportPathMapping = exportPathMapping;
-        this.strict = strict;
-        this.idConflictPolicy = idConflictPolicy;
-        this.overwritePrimaryTypesOfFolders = overwritePrimaryTypesOfFolders;
+        this.importSettings = importSettings;
     }
 
     @Override
@@ -135,8 +119,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         Archive archive = null;
         try {
             session = getSession(resourceResolver);
-            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, cugHandling, importMode,
-                    autosaveThreshold, strict, idConflictPolicy, overwritePrimaryTypesOfFolders);
+            ImportOptions importOptions = VltUtils.getImportOptions(importSettings);
             ErrorListener errorListener = new ErrorListener();
             importOptions.setListener(errorListener);
             Importer importer = new Importer(importOptions);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.api.RegexpPathMapping;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
@@ -82,11 +83,11 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
     private final String name;
     private final Map<String, String> exportPathMapping;
     private final boolean strict;
+    private final IdConflictPolicy idConflictPolicy;
 
     public FileVaultContentSerializer(String name, Packaging packaging, ImportMode importMode, AccessControlHandling aclHandling, AccessControlHandling cugHandling, String[] packageRoots,
                                       String[] nodeFilters, String[] propertyFilters, boolean useBinaryReferences, int autosaveThreshold,
-                                      Map<String, String> exportPathMapping,
-                                      boolean strict) {
+                                      Map<String, String> exportPathMapping, boolean strict, IdConflictPolicy idConflictPolicy) {
         this.name = name;
         this.packaging = packaging;
         this.importMode = importMode;
@@ -99,6 +100,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         this.useBinaryReferences = useBinaryReferences;
         this.exportPathMapping = exportPathMapping;
         this.strict = strict;
+        this.idConflictPolicy = idConflictPolicy;
     }
 
     @Override
@@ -131,7 +133,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         Archive archive = null;
         try {
             session = getSession(resourceResolver);
-            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, cugHandling, importMode, autosaveThreshold, strict);
+            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, cugHandling, importMode, autosaveThreshold, strict, idConflictPolicy);
             ErrorListener errorListener = new ErrorListener();
             importOptions.setListener(errorListener);
             Importer importer = new Importer(importOptions);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializer.java
@@ -84,10 +84,11 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
     private final Map<String, String> exportPathMapping;
     private final boolean strict;
     private final IdConflictPolicy idConflictPolicy;
+    private final boolean overwritePrimaryTypesOfFolders;
 
     public FileVaultContentSerializer(String name, Packaging packaging, ImportMode importMode, AccessControlHandling aclHandling, AccessControlHandling cugHandling, String[] packageRoots,
-                                      String[] nodeFilters, String[] propertyFilters, boolean useBinaryReferences, int autosaveThreshold,
-                                      Map<String, String> exportPathMapping, boolean strict, IdConflictPolicy idConflictPolicy) {
+                                      String[] nodeFilters, String[] propertyFilters, boolean useBinaryReferences, int autosaveThreshold, Map<String, String> exportPathMapping,
+                                      boolean strict, IdConflictPolicy idConflictPolicy, boolean overwritePrimaryTypesOfFolders) {
         this.name = name;
         this.packaging = packaging;
         this.importMode = importMode;
@@ -101,6 +102,7 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         this.exportPathMapping = exportPathMapping;
         this.strict = strict;
         this.idConflictPolicy = idConflictPolicy;
+        this.overwritePrimaryTypesOfFolders = overwritePrimaryTypesOfFolders;
     }
 
     @Override
@@ -133,7 +135,8 @@ public class FileVaultContentSerializer implements DistributionContentSerializer
         Archive archive = null;
         try {
             session = getSession(resourceResolver);
-            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, cugHandling, importMode, autosaveThreshold, strict, idConflictPolicy);
+            ImportOptions importOptions = VltUtils.getImportOptions(aclHandling, cugHandling, importMode,
+                    autosaveThreshold, strict, idConflictPolicy, overwritePrimaryTypesOfFolders);
             ErrorListener errorListener = new ErrorListener();
             importOptions.setListener(errorListener);
             Importer importer = new Importer(importOptions);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/ImportSettings.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/ImportSettings.java
@@ -18,20 +18,44 @@
  */
 package org.apache.sling.distribution.serialization.impl.vlt;
 
-import lombok.Builder;
-import lombok.Data;
 import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 
-@Data
-@Builder
+/**
+ * Settings that control the package import.
+ */
 public class ImportSettings {
-    private ImportMode importMode;
-    private AccessControlHandling aclHandling;
-    private AccessControlHandling cugHandling;
-    private int autosaveThreshold;
-    private boolean strict;
-    private IdConflictPolicy idConflictPolicy;
-    private boolean overwritePrimaryTypesOfFolders;
+    private final ImportMode importMode;
+    private final AccessControlHandling aclHandling;
+    private final AccessControlHandling cugHandling;
+    private final int autosaveThreshold;
+    private final boolean isStrict;
+    private final boolean overwritePrimaryTypesOfFolders;
+    private final IdConflictPolicy idConflictPolicy;
+
+    public ImportSettings(ImportMode importMode, AccessControlHandling aclHandling, AccessControlHandling cugHandling, int autosaveThreshold,
+                          boolean isStrict, boolean overwritePrimaryTypesOfFolders, IdConflictPolicy idConflictPolicy) {
+        this.importMode = importMode;
+        this.aclHandling = aclHandling;
+        this.cugHandling = cugHandling;
+        this.autosaveThreshold = autosaveThreshold;
+        this.isStrict = isStrict;
+        this.overwritePrimaryTypesOfFolders = overwritePrimaryTypesOfFolders;
+        this.idConflictPolicy = idConflictPolicy;
+    }
+
+    public ImportMode getImportMode() { return importMode; }
+
+    public AccessControlHandling getAclHandling() { return aclHandling; }
+
+    public AccessControlHandling getCugHandling() { return cugHandling; }
+
+    public int getAutosaveThreshold() { return autosaveThreshold; }
+
+    public boolean isStrict() { return isStrict; }
+
+    public boolean isOverwritePrimaryTypesOfFolders() { return overwritePrimaryTypesOfFolders; }
+
+    public IdConflictPolicy getIdConflictPolicy() { return idConflictPolicy; }
 }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/ImportSettings.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/ImportSettings.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.serialization.impl.vlt;
+
+import lombok.Builder;
+import lombok.Data;
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
+import org.apache.jackrabbit.vault.fs.api.ImportMode;
+import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
+
+@Data
+@Builder
+public class ImportSettings {
+    private ImportMode importMode;
+    private AccessControlHandling aclHandling;
+    private AccessControlHandling cugHandling;
+    private int autosaveThreshold;
+    private boolean strict;
+    private IdConflictPolicy idConflictPolicy;
+    private boolean overwritePrimaryTypesOfFolders;
+}

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -175,7 +175,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
         @AttributeDefinition(
                 name = "ID Conflict Policy",
                 description = "Node id conflict policy to be used during import")
-        IdConflictPolicy idConflictPolicy() default IdConflictPolicy.FAIL;
+        IdConflictPolicy idConflictPolicy() default IdConflictPolicy.LEGACY;
     }
 
     private static final long DEFAULT_PACKAGE_CLEANUP_DELAY = 60L;

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -172,6 +172,8 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
                 description = "Node id conflict policy to use during import")
         IdConflictPolicy idConflictPolicy() default IdConflictPolicy.FAIL;
 
+        @AttributeDefinition(name = "Legacy Folder Primary Type Mode", description = "Whether to overwrite the primary type of folders during imports")
+        boolean overwritePrimaryTypesOfFolders() default true;
     }
 
     private static final long DEFAULT_PACKAGE_CLEANUP_DELAY = 60L;
@@ -236,13 +238,14 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
         Map<String, String> pathsMapping = toMap(conf.pathsMapping(), new String[0]);
         pathsMapping = SettingsUtils.removeEmptyEntries(pathsMapping);
 
+        // import settings
         boolean strictImport = conf.strictImport();
-
+        boolean overwritePrimaryTypesOfFolders = conf.overwritePrimaryTypesOfFolders();
         IdConflictPolicy idConflictPolicy = conf.idConflictPolicy();
 
         DistributionContentSerializer contentSerializer = new FileVaultContentSerializer(name, packaging, importMode, aclHandling, cugHandling,
                 packageRoots, packageNodeFilters, packagePropertyFilters, useBinaryReferences, autosaveThreshold,
-                pathsMapping, strictImport, idConflictPolicy);
+                pathsMapping, strictImport, idConflictPolicy, overwritePrimaryTypesOfFolders);
 
         DistributionPackageBuilder wrapped;
         if ("filevlt".equals(type)) {

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.distribution.serialization.impl.vlt;
 
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.packaging.Packaging;
@@ -165,8 +166,14 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
                 name = "Install a content package in a strict mode",
                 description = "Flag to mark an error response will be thrown, if a content package will incorrectly installed")
         boolean strictImport() default DEFAULT_STRICT_IMPORT_SETTINGS;
+
+        @AttributeDefinition(
+                name = "ID Conflict Policy",
+                description = "Node id conflict policy to use during import")
+        IdConflictPolicy idConflictPolicy() default IdConflictPolicy.FAIL;
+
     }
-    
+
     private static final long DEFAULT_PACKAGE_CLEANUP_DELAY = 60L;
     // 1M
     private static final int DEFAULT_FILE_THRESHOLD_VALUE = 1;
@@ -175,7 +182,6 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
     private static final String DEFAULT_DIGEST_ALGORITHM = "NONE";
     private static final int DEFAULT_MONITORING_QUEUE_SIZE = 0;
     private static final boolean DEFAULT_STRICT_IMPORT_SETTINGS = true;
-
 
     @Reference
     private Packaging packaging;
@@ -232,8 +238,11 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
 
         boolean strictImport = conf.strictImport();
 
+        IdConflictPolicy idConflictPolicy = conf.idConflictPolicy();
+
         DistributionContentSerializer contentSerializer = new FileVaultContentSerializer(name, packaging, importMode, aclHandling, cugHandling,
-                packageRoots, packageNodeFilters, packagePropertyFilters, useBinaryReferences, autosaveThreshold, pathsMapping, strictImport);
+                packageRoots, packageNodeFilters, packagePropertyFilters, useBinaryReferences, autosaveThreshold,
+                pathsMapping, strictImport, idConflictPolicy);
 
         DistributionPackageBuilder wrapped;
         if ("filevlt".equals(type)) {
@@ -301,7 +310,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
     * (taken and adjusted from PropertiesUtil, because the handy toMap() function is not available as
     * part of the metatype functionality
     * 
-    * @param propValue The object to convert.
+    * @param values The path mappings.
     * @param defaultArray The default array converted to map.
     * @return Map value
     */

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -42,6 +42,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -51,9 +53,13 @@ import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.osgi.service.metatype.annotations.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Dictionary;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -161,19 +167,6 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
                 description = "List of paths that require be mapped." +
                 "The format is {sourcePattern}={destinationPattern}, e.g. /etc/(.*)=/var/$1/some or simply /data=/bak")
         String[] pathsMapping();
-        
-        @AttributeDefinition(
-                name = "Install a content package in a strict mode",
-                description = "Flag to mark an error response will be thrown, if a content package will incorrectly installed")
-        boolean strictImport() default DEFAULT_STRICT_IMPORT_SETTINGS;
-
-        @AttributeDefinition(
-                name = "ID Conflict Policy",
-                description = "Node id conflict policy to use during import")
-        IdConflictPolicy idConflictPolicy() default IdConflictPolicy.FAIL;
-
-        @AttributeDefinition(name = "Legacy Folder Primary Type Mode", description = "Whether to overwrite the primary type of folders during imports")
-        boolean overwritePrimaryTypesOfFolders() default true;
     }
 
     private static final long DEFAULT_PACKAGE_CLEANUP_DELAY = 60L;
@@ -183,13 +176,26 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
     private static final boolean DEFAULT_USE_OFF_HEAP_MEMORY = false;
     private static final String DEFAULT_DIGEST_ALGORITHM = "NONE";
     private static final int DEFAULT_MONITORING_QUEUE_SIZE = 0;
-    private static final boolean DEFAULT_STRICT_IMPORT_SETTINGS = true;
+
+    // importer setting constants, can be removed once JCRVLT-656 is implemented
+    private static final String PACKAGING_CONFIGURATION_PID = "org.apache.jackrabbit.vault.packaging.impl.PackagingImpl";
+    private static final String PROPERTY_IS_STRICT = "isStrict";
+    private static final String PROPERTY_DEFAULT_ID_CONFLICT_POLICY = "defaultIdConflictPolicy";
+    private static final String PROPERTY_OVERWRITE_PRIMARY_TYPES_OF_FOLDER = "overwritePrimaryTypesOfFolders";
+    private static final boolean DEFAULT_IS_STRICT = true;
+    private static final boolean DEFAULT_OVERWRITE_PRIMARY_TYPES_OF_FOLDER = true;
+    private static final IdConflictPolicy DEFAULT_ID_CONFLICT_POLICY = IdConflictPolicy.FAIL;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Reference
     private Packaging packaging;
 
     @Reference
     private ResourceResolverFactory resolverFactory;
+
+    @Reference
+    private ConfigurationAdmin configurationAdmin;
 
     private ServiceRegistration<Runnable> packageCleanup = null;
 
@@ -212,26 +218,10 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
 
         String tempFsFolder = SettingsUtils.removeEmptyEntry(conf.tempFsFolder());
         boolean useBinaryReferences = conf.useBinaryReferences();
-        int autosaveThreshold = conf.autoSaveThreshold();
 
         String digestAlgorithm = conf.digestAlgorithm();
         if (DEFAULT_DIGEST_ALGORITHM.equals(digestAlgorithm)) {
             digestAlgorithm = null;
-        }
-
-        ImportMode importMode = null;
-        if (importModeString != null) {
-            importMode = ImportMode.valueOf(importModeString.trim());
-        }
-
-        AccessControlHandling aclHandling = null;
-        if (aclHandlingString != null) {
-            aclHandling = AccessControlHandling.valueOf(aclHandlingString.trim());
-        }
-
-        AccessControlHandling cugHandling = null;
-        if (cugHandlingString != null) {
-            cugHandling = AccessControlHandling.valueOf(cugHandlingString.trim());
         }
 
         // check the mount path patterns, if any
@@ -239,13 +229,39 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
         pathsMapping = SettingsUtils.removeEmptyEntries(pathsMapping);
 
         // import settings
-        boolean strictImport = conf.strictImport();
-        boolean overwritePrimaryTypesOfFolders = conf.overwritePrimaryTypesOfFolders();
-        IdConflictPolicy idConflictPolicy = conf.idConflictPolicy();
+        ImportSettings importSettings = ImportSettings.builder().build();
+        importSettings.setAutosaveThreshold(conf.autoSaveThreshold());
 
-        DistributionContentSerializer contentSerializer = new FileVaultContentSerializer(name, packaging, importMode, aclHandling, cugHandling,
-                packageRoots, packageNodeFilters, packagePropertyFilters, useBinaryReferences, autosaveThreshold,
-                pathsMapping, strictImport, idConflictPolicy, overwritePrimaryTypesOfFolders);
+        if (importModeString != null) {
+            importSettings.setImportMode(ImportMode.valueOf(importModeString.trim()));
+        }
+
+        if (aclHandlingString != null) {
+            importSettings.setAclHandling(AccessControlHandling.valueOf(aclHandlingString.trim()));
+        }
+
+        if (cugHandlingString != null) {
+            importSettings.setCugHandling(AccessControlHandling.valueOf(cugHandlingString.trim()));
+        }
+
+        // read settings from Packaging configuration
+        importSettings.setStrict(DEFAULT_IS_STRICT);
+        importSettings.setOverwritePrimaryTypesOfFolders(DEFAULT_OVERWRITE_PRIMARY_TYPES_OF_FOLDER);
+        importSettings.setIdConflictPolicy(DEFAULT_ID_CONFLICT_POLICY);
+        try {
+            Configuration packagingConfig = configurationAdmin.getConfiguration(PACKAGING_CONFIGURATION_PID);
+            Dictionary<String, Object> properties = packagingConfig.getProperties();
+            if (properties != null) {
+                importSettings.setStrict((Boolean) properties.get(PROPERTY_IS_STRICT));
+                importSettings.setOverwritePrimaryTypesOfFolders((Boolean) properties.get(PROPERTY_OVERWRITE_PRIMARY_TYPES_OF_FOLDER));
+                importSettings.setIdConflictPolicy((IdConflictPolicy) properties.get(PROPERTY_DEFAULT_ID_CONFLICT_POLICY));
+            }
+        } catch (IOException e) {
+            log.warn("Could not read the OSGi configuration {}, falling back on default values.", PACKAGING_CONFIGURATION_PID);
+        }
+
+        DistributionContentSerializer contentSerializer = new FileVaultContentSerializer(name, packaging, packageRoots, packageNodeFilters,
+                packagePropertyFilters, useBinaryReferences, pathsMapping, importSettings);
 
         DistributionPackageBuilder wrapped;
         if ("filevlt".equals(type)) {

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
@@ -41,7 +41,6 @@ import java.util.zip.Deflater;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
@@ -87,8 +86,7 @@ public class VltUtils {
         for (String path : distributionRequest.getPaths()) {
 
             // Set node path filters
-            List<String> patterns = new ArrayList<String>();
-            patterns.addAll(Arrays.asList(distributionRequest.getFilters(path)));
+            List<String> patterns = new ArrayList<String>(Arrays.asList(distributionRequest.getFilters(path)));
             boolean deep = distributionRequest.isDeep(path);
             PathFilterSet nodeFilterSet = new PathFilterSet(path);
             if (!deep) {

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
@@ -230,23 +230,22 @@ public class VltUtils {
         return packageRoot;
     }
 
-    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, AccessControlHandling cugHandling, ImportMode importMode, int autosaveThreshold,
-                                                 boolean strict, IdConflictPolicy idConflictPolicy, boolean overwritePrimaryTypesOfFolders) {
+    public static ImportOptions getImportOptions(ImportSettings importSettings) {
         ImportOptions opts = new ImportOptions();
-        if (aclHandling != null) {
-            opts.setAccessControlHandling(aclHandling);
+        if (importSettings.getAclHandling() != null) {
+            opts.setAccessControlHandling(importSettings.getAclHandling());
         } else {
             // default to overwrite
             opts.setAccessControlHandling(AccessControlHandling.OVERWRITE);
         }
-        if (cugHandling != null) {
-            opts.setCugHandling(cugHandling);
+        if (importSettings.getCugHandling() != null) {
+            opts.setCugHandling(importSettings.getCugHandling());
         } else {
             // default to overwrite
             opts.setCugHandling(AccessControlHandling.OVERWRITE);
         }
-        if (importMode != null) {
-            opts.setImportMode(importMode);
+        if (importSettings.getImportMode() != null) {
+            opts.setImportMode(importSettings.getImportMode());
         } else {
             // default to update
             opts.setImportMode(ImportMode.UPDATE);
@@ -254,15 +253,15 @@ public class VltUtils {
 
         opts.setPatchKeepInRepo(false);
 
-        if (autosaveThreshold >= 0) {
-            opts.setAutoSaveThreshold(autosaveThreshold);
+        if (importSettings.getAutosaveThreshold() >= 0) {
+            opts.setAutoSaveThreshold(importSettings.getAutosaveThreshold());
         }
 
-        opts.setStrict(strict);
+        opts.setStrict(importSettings.isStrict());
 
-        opts.setIdConflictPolicy(idConflictPolicy);
+        opts.setIdConflictPolicy(importSettings.getIdConflictPolicy());
 
-        opts.setOverwritePrimaryTypesOfFolders(overwritePrimaryTypesOfFolders);
+        opts.setOverwritePrimaryTypesOfFolders(importSettings.isOverwritePrimaryTypesOfFolders());
 
         return opts;
     }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
@@ -41,9 +41,11 @@ import java.util.zip.Deflater;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
 import org.apache.jackrabbit.vault.fs.api.WorkspaceFilter;
+import org.apache.jackrabbit.vault.fs.config.ConfigurationException;
 import org.apache.jackrabbit.vault.fs.config.DefaultMetaInf;
 import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.config.MetaInf;
@@ -79,7 +81,7 @@ public class VltUtils {
     private static final String MAPPING_DELIMITER = ";";
 
     public static WorkspaceFilter createFilter(DistributionRequest distributionRequest, NavigableMap<String, List<String>> nodeFilters,
-                                               NavigableMap<String, List<String>> propertyFilters) {
+                                               NavigableMap<String, List<String>> propertyFilters) throws ConfigurationException {
         DefaultWorkspaceFilter filter = new DefaultWorkspaceFilter();
 
         for (String path : distributionRequest.getPaths()) {
@@ -122,7 +124,8 @@ public class VltUtils {
         return paths;
     }
 
-    private static void initFilterSet(PathFilterSet filterSet, NavigableMap<String, List<String>> globalFilters, List<String> patterns) {
+    private static void initFilterSet(PathFilterSet filterSet, NavigableMap<String, List<String>> globalFilters,
+                                      List<String> patterns) throws ConfigurationException {
 
         // add the most specific filter rules
         String root = filterSet.getRoot();
@@ -227,7 +230,8 @@ public class VltUtils {
         return packageRoot;
     }
 
-    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, AccessControlHandling cugHandling, ImportMode importMode, int autosaveThreshold, boolean strict) {
+    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, AccessControlHandling cugHandling, ImportMode importMode,
+                                                 int autosaveThreshold, boolean strict, IdConflictPolicy idConflictPolicy) {
         ImportOptions opts = new ImportOptions();
         if (aclHandling != null) {
             opts.setAccessControlHandling(aclHandling);
@@ -255,6 +259,8 @@ public class VltUtils {
         }
 
         opts.setStrict(strict);
+
+        opts.setIdConflictPolicy(idConflictPolicy);
 
         return opts;
     }
@@ -435,7 +441,7 @@ public class VltUtils {
         return new SimpleDistributionRequest(requestType, paths.toArray(new String[paths.size()]), deepPaths, filters);
     }
 
-    private static PathFilterSet.Entry<DefaultPathFilter> extractPathPattern(String pattern) {
+    private static PathFilterSet.Entry<DefaultPathFilter> extractPathPattern(String pattern) throws ConfigurationException {
         PathFilterSet.Entry<DefaultPathFilter> result;
         if (pattern.startsWith("+")) {
             result = new PathFilterSet.Entry<DefaultPathFilter>(new DefaultPathFilter(pattern.substring(1)), true);

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
@@ -230,8 +230,8 @@ public class VltUtils {
         return packageRoot;
     }
 
-    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, AccessControlHandling cugHandling, ImportMode importMode,
-                                                 int autosaveThreshold, boolean strict, IdConflictPolicy idConflictPolicy) {
+    public static ImportOptions getImportOptions(AccessControlHandling aclHandling, AccessControlHandling cugHandling, ImportMode importMode, int autosaveThreshold,
+                                                 boolean strict, IdConflictPolicy idConflictPolicy, boolean overwritePrimaryTypesOfFolders) {
         ImportOptions opts = new ImportOptions();
         if (aclHandling != null) {
             opts.setAccessControlHandling(aclHandling);
@@ -261,6 +261,8 @@ public class VltUtils {
         opts.setStrict(strict);
 
         opts.setIdConflictPolicy(idConflictPolicy);
+
+        opts.setOverwritePrimaryTypesOfFolders(overwritePrimaryTypesOfFolders);
 
         return opts;
     }

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -92,7 +92,8 @@ public class LocalDistributionPackageImporterTest {
                 -1,
                 null,
                 false,
-                IdConflictPolicy.FAIL
+                IdConflictPolicy.FAIL,
+                true
         );
 
         DistributionPackageBuilder builder =

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -19,6 +19,7 @@
 package org.apache.sling.distribution.packaging.impl.importer;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.packaging.impl.PackagingImpl;
@@ -90,7 +91,8 @@ public class LocalDistributionPackageImporterTest {
                 false,
                 -1,
                 null,
-                false
+                false,
+                IdConflictPolicy.FAIL
         );
 
         DistributionPackageBuilder builder =

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -81,7 +81,7 @@ public class LocalDistributionPackageImporterTest {
                 new LocalDistributionPackageImporter("mockImporter", distributionEventFactory, packageBuilder);
 
         ImportSettings importSettings = new ImportSettings(ImportMode.UPDATE, AccessControlHandling.IGNORE,
-                AccessControlHandling.IGNORE, -1, false, false, IdConflictPolicy.FAIL);
+                AccessControlHandling.IGNORE, -1, false, false, IdConflictPolicy.LEGACY);
 
         FileVaultContentSerializer vaultSerializer = new FileVaultContentSerializer(
                 "importPackageWithLargeHeader",

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -36,6 +36,7 @@ import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.apache.sling.distribution.packaging.impl.DistributionPackageUtils;
 import org.apache.sling.distribution.packaging.impl.FileDistributionPackageBuilder;
 import org.apache.sling.distribution.serialization.impl.vlt.FileVaultContentSerializer;
+import org.apache.sling.distribution.serialization.impl.vlt.ImportSettings;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Rule;
@@ -79,21 +80,25 @@ public class LocalDistributionPackageImporterTest {
         LocalDistributionPackageImporter localdistributionPackageImporter =
                 new LocalDistributionPackageImporter("mockImporter", distributionEventFactory, packageBuilder);
 
+        ImportSettings importSettings = ImportSettings.builder()
+                .importMode(ImportMode.UPDATE)
+                .aclHandling(AccessControlHandling.IGNORE)
+                .cugHandling(AccessControlHandling.IGNORE)
+                .autosaveThreshold(-1)
+                .strict(false)
+                .idConflictPolicy(IdConflictPolicy.FAIL)
+                .overwritePrimaryTypesOfFolders(false)
+                .build();
+
         FileVaultContentSerializer vaultSerializer = new FileVaultContentSerializer(
                 "importPackageWithLargeHeader",
                 new PackagingImpl(),
-                ImportMode.UPDATE,
-                AccessControlHandling.IGNORE,
-                AccessControlHandling.IGNORE,
                 new String[0],
                 new String[0],
                 new String[0],
                 false,
-                -1,
                 null,
-                false,
-                IdConflictPolicy.FAIL,
-                true
+                importSettings
         );
 
         DistributionPackageBuilder builder =

--- a/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
+++ b/src/test/java/org/apache/sling/distribution/packaging/impl/importer/LocalDistributionPackageImporterTest.java
@@ -80,15 +80,8 @@ public class LocalDistributionPackageImporterTest {
         LocalDistributionPackageImporter localdistributionPackageImporter =
                 new LocalDistributionPackageImporter("mockImporter", distributionEventFactory, packageBuilder);
 
-        ImportSettings importSettings = ImportSettings.builder()
-                .importMode(ImportMode.UPDATE)
-                .aclHandling(AccessControlHandling.IGNORE)
-                .cugHandling(AccessControlHandling.IGNORE)
-                .autosaveThreshold(-1)
-                .strict(false)
-                .idConflictPolicy(IdConflictPolicy.FAIL)
-                .overwritePrimaryTypesOfFolders(false)
-                .build();
+        ImportSettings importSettings = new ImportSettings(ImportMode.UPDATE, AccessControlHandling.IGNORE,
+                AccessControlHandling.IGNORE, -1, false, false, IdConflictPolicy.FAIL);
 
         FileVaultContentSerializer vaultSerializer = new FileVaultContentSerializer(
                 "importPackageWithLargeHeader",

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
@@ -74,18 +74,23 @@ public class FileVaultContentSerializerTest {
     @Test
     public void testExportToStream() throws Exception {
         Packaging packaging = mock(Packaging.class);
-
-        ImportMode importMode = ImportMode.REPLACE;
-        AccessControlHandling aclHandling = AccessControlHandling.IGNORE;
+        ImportSettings importSettings = ImportSettings.builder()
+                .importMode(ImportMode.REPLACE)
+                .aclHandling(AccessControlHandling.IGNORE)
+                .cugHandling(AccessControlHandling.IGNORE)
+                .autosaveThreshold(1024)
+                .strict(false)
+                .idConflictPolicy(IdConflictPolicy.FAIL)
+                .overwritePrimaryTypesOfFolders(true)
+                .build();
 
         String[] packageRoots = new String[]{"/etc/packages"};
         String[] nodeFilters = new String[0];
         String[] propertyFilters = new String[0];
         boolean useReferences = false;
         int threshold = 1024;
-        FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
-                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, threshold,
-                new HashMap<String, String>(), false, IdConflictPolicy.FAIL, true);
+        FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, packageRoots, nodeFilters,
+                propertyFilters, useReferences, new HashMap<String, String>(), importSettings);
 
         ResourceResolver sessionResolver = mock(ResourceResolver.class);
         Session session = mock(Session.class);
@@ -118,17 +123,22 @@ public class FileVaultContentSerializerTest {
     @Test
     public void testImportFromStream() throws Exception {
         Packaging packaging = mock(Packaging.class);
-        ImportMode importMode = ImportMode.REPLACE;
-        AccessControlHandling aclHandling = AccessControlHandling.IGNORE;
+        ImportSettings importSettings = ImportSettings.builder()
+                .importMode(ImportMode.REPLACE)
+                .aclHandling(AccessControlHandling.IGNORE)
+                .cugHandling(AccessControlHandling.IGNORE)
+                .autosaveThreshold(1024)
+                .strict(true)
+                .idConflictPolicy(IdConflictPolicy.FAIL)
+                .overwritePrimaryTypesOfFolders(true)
+                .build();
 
         String[] packageRoots = new String[]{"/"};
         String[] nodeFilters = new String[0];
         String[] propertyFilters = new String[0];
         boolean useReferences = false;
-        int thershold = 1024;
-        FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
-                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, thershold,
-                new HashMap<String, String>(), true, IdConflictPolicy.FAIL, true);
+        FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, packageRoots, nodeFilters,
+                propertyFilters, useReferences, new HashMap<String, String>(), importSettings);
 
         File file = new File(getClass().getResource("/vlt/dp.vlt").getFile());
 

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
@@ -85,7 +85,7 @@ public class FileVaultContentSerializerTest {
         int threshold = 1024;
         FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
                 aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, threshold,
-                new HashMap<String, String>(), false, IdConflictPolicy.FAIL);
+                new HashMap<String, String>(), false, IdConflictPolicy.FAIL, true);
 
         ResourceResolver sessionResolver = mock(ResourceResolver.class);
         Session session = mock(Session.class);
@@ -128,7 +128,7 @@ public class FileVaultContentSerializerTest {
         int thershold = 1024;
         FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
                 aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, thershold,
-                new HashMap<String, String>(), true, IdConflictPolicy.FAIL);
+                new HashMap<String, String>(), true, IdConflictPolicy.FAIL, true);
 
         File file = new File(getClass().getResource("/vlt/dp.vlt").getFile());
 

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
@@ -27,6 +27,7 @@ import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 
+import org.apache.jackrabbit.vault.fs.api.IdConflictPolicy;
 import org.apache.jackrabbit.vault.fs.api.ImportMode;
 import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.packaging.ExportOptions;
@@ -83,7 +84,8 @@ public class FileVaultContentSerializerTest {
         boolean useReferences = false;
         int threshold = 1024;
         FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
-                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, threshold, new HashMap<String, String>(), false);
+                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, threshold,
+                new HashMap<String, String>(), false, IdConflictPolicy.FAIL);
 
         ResourceResolver sessionResolver = mock(ResourceResolver.class);
         Session session = mock(Session.class);
@@ -125,7 +127,8 @@ public class FileVaultContentSerializerTest {
         boolean useReferences = false;
         int thershold = 1024;
         FileVaultContentSerializer fileVaultContentSerializer = new FileVaultContentSerializer("vlt", packaging, importMode,
-                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, thershold, new HashMap<String, String>(), true);
+                aclHandling, aclHandling, packageRoots, nodeFilters, propertyFilters, useReferences, thershold,
+                new HashMap<String, String>(), true, IdConflictPolicy.FAIL);
 
         File file = new File(getClass().getResource("/vlt/dp.vlt").getFile());
 

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
@@ -75,7 +75,7 @@ public class FileVaultContentSerializerTest {
     public void testExportToStream() throws Exception {
         Packaging packaging = mock(Packaging.class);
         ImportSettings importSettings = new ImportSettings(ImportMode.REPLACE, AccessControlHandling.IGNORE,
-                AccessControlHandling.IGNORE, 1024, false, false, IdConflictPolicy.FAIL);
+                AccessControlHandling.IGNORE, 1024, false, false, IdConflictPolicy.LEGACY);
 
         String[] packageRoots = new String[]{"/etc/packages"};
         String[] nodeFilters = new String[0];
@@ -117,7 +117,7 @@ public class FileVaultContentSerializerTest {
     public void testImportFromStream() throws Exception {
         Packaging packaging = mock(Packaging.class);
         ImportSettings importSettings = new ImportSettings(ImportMode.REPLACE, AccessControlHandling.IGNORE,
-                AccessControlHandling.IGNORE, 1024, true, true, IdConflictPolicy.FAIL);
+                AccessControlHandling.IGNORE, 1024, true, true, IdConflictPolicy.LEGACY);
 
         String[] packageRoots = new String[]{"/"};
         String[] nodeFilters = new String[0];

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/FileVaultContentSerializerTest.java
@@ -74,15 +74,8 @@ public class FileVaultContentSerializerTest {
     @Test
     public void testExportToStream() throws Exception {
         Packaging packaging = mock(Packaging.class);
-        ImportSettings importSettings = ImportSettings.builder()
-                .importMode(ImportMode.REPLACE)
-                .aclHandling(AccessControlHandling.IGNORE)
-                .cugHandling(AccessControlHandling.IGNORE)
-                .autosaveThreshold(1024)
-                .strict(false)
-                .idConflictPolicy(IdConflictPolicy.FAIL)
-                .overwritePrimaryTypesOfFolders(true)
-                .build();
+        ImportSettings importSettings = new ImportSettings(ImportMode.REPLACE, AccessControlHandling.IGNORE,
+                AccessControlHandling.IGNORE, 1024, false, false, IdConflictPolicy.FAIL);
 
         String[] packageRoots = new String[]{"/etc/packages"};
         String[] nodeFilters = new String[0];
@@ -123,15 +116,8 @@ public class FileVaultContentSerializerTest {
     @Test
     public void testImportFromStream() throws Exception {
         Packaging packaging = mock(Packaging.class);
-        ImportSettings importSettings = ImportSettings.builder()
-                .importMode(ImportMode.REPLACE)
-                .aclHandling(AccessControlHandling.IGNORE)
-                .cugHandling(AccessControlHandling.IGNORE)
-                .autosaveThreshold(1024)
-                .strict(true)
-                .idConflictPolicy(IdConflictPolicy.FAIL)
-                .overwritePrimaryTypesOfFolders(true)
-                .build();
+        ImportSettings importSettings = new ImportSettings(ImportMode.REPLACE, AccessControlHandling.IGNORE,
+                AccessControlHandling.IGNORE, 1024, true, true, IdConflictPolicy.FAIL);
 
         String[] packageRoots = new String[]{"/"};
         String[] nodeFilters = new String[0];

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtilsTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtilsTest.java
@@ -119,7 +119,7 @@ public class VltUtilsTest {
     }
     
     @Test
-    public void testCreateFilterWithParenthesis() {
+    public void testCreateFilterWithParenthesis() throws Exception {
         DistributionRequest request = new SimpleDistributionRequest(ADD, false, "/nodewith(shouldwork");
         NavigableMap<String, List<String>> nodeFilters = new TreeMap<String, List<String>>();
         NavigableMap<String, List<String>> propFilters = new TreeMap<String, List<String>>();


### PR DESCRIPTION
Set the `idConflictPolicy` & `overwritePrimaryTypesOfFoldersByDefault ` in the `ImportOptions` so that the `Importer` applies the conflict policy while installing content packages.

Instead of using the values from the OSGi config of `Packaging`, I added a new properties in the `DistributionPackageBuilder` configuration so that user is able to configure the `DistributionPackageBuilder` service at one place.