### PR TITLE
SLING-12783: align DistributionPackageBuilder#createPackage() with javadoc

### DIFF
--- a/src/main/java/org/apache/sling/distribution/monitor/impl/MonitoringDistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/monitor/impl/MonitoringDistributionPackageBuilder.java
@@ -33,6 +33,7 @@ import org.apache.sling.distribution.packaging.DistributionPackage;
 import org.apache.sling.distribution.packaging.DistributionPackageBuilder;
 import org.apache.sling.distribution.packaging.DistributionPackageInfo;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
@@ -59,12 +60,12 @@ public final class MonitoringDistributionPackageBuilder implements DistributionP
         return wrapped.getType();
     }
 
-    @NotNull
+    @Nullable
     @Override
     public DistributionPackage createPackage(@NotNull ResourceResolver resourceResolver, @NotNull DistributionRequest request) throws DistributionException {
         long start = System.currentTimeMillis();
         DistributionPackage distributionPackage = wrapped.createPackage(resourceResolver, request);
-        if (queueCapacity > 0) {
+        if (queueCapacity > 0 && distributionPackage != null) {
             registerDistributionPackageMBean(start, distributionPackage);
         }
         return distributionPackage;

--- a/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageBuilder.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/DistributionPackageBuilder.java
@@ -46,7 +46,7 @@ public interface DistributionPackageBuilder {
      * @return a {@link DistributionPackage} or <code>null</code> if it could not be created
      * @throws org.apache.sling.distribution.common.DistributionException if any error occurs while creating the package, or if the resource resolver is not authorized to do that
      */
-    @NotNull
+    @Nullable
     DistributionPackage createPackage(@NotNull ResourceResolver resourceResolver, @NotNull DistributionRequest request) throws DistributionException;
 
     /**

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/exporter/LocalDistributionPackageExporter.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/exporter/LocalDistributionPackageExporter.java
@@ -44,7 +44,9 @@ public class LocalDistributionPackageExporter implements DistributionPackageExpo
         DistributionPackage createdPackage = packageBuilder.createPackage(resourceResolver, distributionRequest);
 
         try {
-            packageProcessor.process(createdPackage);
+            if (createdPackage != null) {
+                packageProcessor.process(createdPackage);
+            }
         } finally {
             DistributionPackageUtils.closeSafely(createdPackage);
         }


### PR DESCRIPTION
The javadoc mentions a possible `null` return value for DistributionPackageBuilder#createPackage(). This PR adjusts method annotation to `Nullable` accordingly and all places that would eventually throw if the package is indeed `null`.