### PR TITLE
SLING-11026: Use dedicated threadpool for ResourceDistributionPackageCleanup

### DIFF
--- a/src/main/java/org/apache/sling/distribution/component/impl/DistributionComponentConstants.java
+++ b/src/main/java/org/apache/sling/distribution/component/impl/DistributionComponentConstants.java
@@ -38,5 +38,10 @@ public class DistributionComponentConstants {
      * Property representing component name
      */
     public static final String PN_NAME = "name";
+    
+    /**
+     * Common thread pool name for distribution components.
+     */
+    public static final String THREAD_POOL_NAME = "org-apache-sling-distribution";
 
 }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
@@ -186,7 +186,7 @@ public class DistributionPackageBuilderFactory implements DistributionPackageBui
             Dictionary<String, Object> props = new Hashtable<String, Object>();
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);
             props.put(Scheduler.PROPERTY_SCHEDULER_PERIOD, cleanupDelay);
-            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, "content-distribution");
+            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, "org-apache-sling-distribution");
             packageCleanup = context.registerService(Runnable.class, cleanup, props);
             wrapped = resourceDistributionPackageBuilder;
         }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
@@ -27,6 +27,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.common.DistributionException;
+import org.apache.sling.distribution.component.impl.DistributionComponentConstants;
 import org.apache.sling.distribution.component.impl.SettingsUtils;
 import org.apache.sling.distribution.monitor.impl.MonitoringDistributionPackageBuilder;
 import org.apache.sling.distribution.packaging.DistributionPackage;
@@ -186,7 +187,7 @@ public class DistributionPackageBuilderFactory implements DistributionPackageBui
             Dictionary<String, Object> props = new Hashtable<String, Object>();
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);
             props.put(Scheduler.PROPERTY_SCHEDULER_PERIOD, cleanupDelay);
-            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, "org-apache-sling-distribution");
+            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, DistributionComponentConstants.THREAD_POOL_NAME);
             packageCleanup = context.registerService(Runnable.class, cleanup, props);
             wrapped = resourceDistributionPackageBuilder;
         }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -27,6 +27,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.common.DistributionException;
+import org.apache.sling.distribution.component.impl.DistributionComponentConstants;
 import org.apache.sling.distribution.component.impl.SettingsUtils;
 import org.apache.sling.distribution.monitor.impl.MonitoringDistributionPackageBuilder;
 import org.apache.sling.distribution.packaging.DistributionPackage;
@@ -273,7 +274,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);
             props.put(Scheduler.PROPERTY_SCHEDULER_PERIOD, cleanupDelay);
             props.put(Scheduler.PROPERTY_SCHEDULER_RUN_ON, Scheduler.VALUE_RUN_ON_SINGLE);
-            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, "org-apache-sling-distribution");
+            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, DistributionComponentConstants.THREAD_POOL_NAME);
             packageCleanup = context.registerService(Runnable.class, cleanup, props);
             wrapped = resourceDistributionPackageBuilder;
         }

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -273,6 +273,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);
             props.put(Scheduler.PROPERTY_SCHEDULER_PERIOD, cleanupDelay);
             props.put(Scheduler.PROPERTY_SCHEDULER_RUN_ON, Scheduler.VALUE_RUN_ON_SINGLE);
+            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, "org-apache-sling-distribution");
             packageCleanup = context.registerService(Runnable.class, cleanup, props);
             wrapped = resourceDistributionPackageBuilder;
         }

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactoryTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactoryTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -21,53 +21,35 @@ package org.apache.sling.distribution.serialization.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
-
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.Map;
+import static org.mockito.Mockito.when;
 
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.Scheduler;
+import org.apache.sling.distribution.component.impl.DistributionComponentConstants;
 import org.apache.sling.distribution.serialization.DistributionContentSerializer;
-import org.apache.sling.testing.mock.osgi.MockOsgi;
-import org.junit.Before;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Rule;
 import org.junit.Test;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
+
 public class DistributionPackageBuilderFactoryTest {
 
-    private BundleContext context;
+    @Rule
+    public final OsgiContext context = new OsgiContext();
 
-    @Before
-    public void setUp() {
-        context = MockOsgi.newBundleContext();
-    }
-
-    /**
-     * Tests that the cleanup task has a dedicated thread pool.
-     * see SLING-11026
-     */
     @Test
     public void testCleanupTaskHasDedicatedThreadPool() {
-        context.registerService(ResourceResolverFactory.class, mock(ResourceResolverFactory.class), null);
-        
+        context.registerService(ResourceResolverFactory.class, mock(ResourceResolverFactory.class));
         DistributionContentSerializer contentSerializer = mock(DistributionContentSerializer.class);
-        Map<String, Object> serializerProps = new Hashtable<>();
-        serializerProps.put("name", "test-format");
-        context.registerService(DistributionContentSerializer.class, contentSerializer, (java.util.Dictionary) serializerProps);
-
-        Map<String, Object> config = new HashMap<>();
-        config.put("name", "test-builder");
-        config.put("type", "resource");
-        config.put("format.target", "(name=test-format)");
-
+        when(contentSerializer.getName()).thenReturn("test-format");
+        context.registerService(DistributionContentSerializer.class, contentSerializer, "name", "test-format");
         DistributionPackageBuilderFactory factory = new DistributionPackageBuilderFactory();
-        MockOsgi.injectServices(factory, context);
-        MockOsgi.activate(factory, context, config);
-
-        ServiceReference<Runnable> ref = context.getServiceReference(Runnable.class);
-        assertNotNull("Cleanup task should be registered", ref);
-        
-        assertEquals("org-apache-sling-distribution", ref.getProperty(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL));
+        context.registerInjectActivateService(factory,
+                "name", "test-builder",
+                "type", "resource",
+                "format.target", "(name=test-format)");
+        ServiceReference<Runnable> ref = context.bundleContext().getServiceReference(Runnable.class);
+        assertNotNull("Cleanup task should be registered", ref);        
+        assertEquals(DistributionComponentConstants.THREAD_POOL_NAME, ref.getProperty(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL));
     }
 }

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactoryTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.serialization.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.commons.scheduler.Scheduler;
+import org.apache.sling.distribution.serialization.DistributionContentSerializer;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+public class DistributionPackageBuilderFactoryTest {
+
+    private BundleContext context;
+
+    @Before
+    public void setUp() {
+        context = MockOsgi.newBundleContext();
+    }
+
+    /**
+     * Tests that the cleanup task has a dedicated thread pool.
+     * see SLING-11026
+     */
+    @Test
+    public void testCleanupTaskHasDedicatedThreadPool() {
+        context.registerService(ResourceResolverFactory.class, mock(ResourceResolverFactory.class), null);
+        
+        DistributionContentSerializer contentSerializer = mock(DistributionContentSerializer.class);
+        Map<String, Object> serializerProps = new Hashtable<>();
+        serializerProps.put("name", "test-format");
+        context.registerService(DistributionContentSerializer.class, contentSerializer, (java.util.Dictionary) serializerProps);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("name", "test-builder");
+        config.put("type", "resource");
+        config.put("format.target", "(name=test-format)");
+
+        DistributionPackageBuilderFactory factory = new DistributionPackageBuilderFactory();
+        MockOsgi.injectServices(factory, context);
+        MockOsgi.activate(factory, context, config);
+
+        ServiceReference<Runnable> ref = context.getServiceReference(Runnable.class);
+        assertNotNull("Cleanup task should be registered", ref);
+        
+        assertEquals("org-apache-sling-distribution", ref.getProperty(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL));
+    }
+}

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactoryTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactoryTest.java
@@ -22,47 +22,33 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.Scheduler;
-import org.apache.sling.testing.mock.osgi.MockOsgi;
-import org.junit.Before;
+import org.apache.sling.distribution.component.impl.DistributionComponentConstants;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Rule;
 import org.junit.Test;
-import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
 
 public class VaultDistributionPackageBuilderFactoryTest {
 
-    private BundleContext context;
+    @Rule
+    public final OsgiContext context = new OsgiContext();
 
-    @Before
-    public void setUp() {
-        context = MockOsgi.newBundleContext();
-    }
-
-    /**
-     * Tests that the cleanup task has a dedicated thread pool.
-     * see SLING-11026
-     */
     @Test
     public void testCleanupTaskHasDedicatedThreadPool() {
-        context.registerService(ResourceResolverFactory.class, mock(ResourceResolverFactory.class), null);
-        context.registerService(Packaging.class, mock(Packaging.class), null);
-
-        Map<String, Object> config = new HashMap<>();
-        config.put("name", "test-vault-builder");
-        config.put("type", "jcrvlt"); 
+        context.registerService(ResourceResolverFactory.class, mock(ResourceResolverFactory.class));
+        context.registerService(Packaging.class, mock(Packaging.class));
 
         VaultDistributionPackageBuilderFactory factory = new VaultDistributionPackageBuilderFactory();
-        MockOsgi.injectServices(factory, context);
-        MockOsgi.activate(factory, context, config);
+        context.registerInjectActivateService(factory,
+                "name", "test-builder",
+                "type", "jcrvlt");
 
-        ServiceReference<Runnable> ref = context.getServiceReference(Runnable.class);
+        ServiceReference<Runnable> ref = context.bundleContext().getServiceReference(Runnable.class);
         assertNotNull("Cleanup task should be registered", ref);
 
-        assertEquals("org-apache-sling-distribution", ref.getProperty(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL));
+        assertEquals(DistributionComponentConstants.THREAD_POOL_NAME, ref.getProperty(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL));
     }
 }

--- a/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactoryTest.java
+++ b/src/test/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactoryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.serialization.impl.vlt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.jackrabbit.vault.packaging.Packaging;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.commons.scheduler.Scheduler;
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+public class VaultDistributionPackageBuilderFactoryTest {
+
+    private BundleContext context;
+
+    @Before
+    public void setUp() {
+        context = MockOsgi.newBundleContext();
+    }
+
+    /**
+     * Tests that the cleanup task has a dedicated thread pool.
+     * see SLING-11026
+     */
+    @Test
+    public void testCleanupTaskHasDedicatedThreadPool() {
+        context.registerService(ResourceResolverFactory.class, mock(ResourceResolverFactory.class), null);
+        context.registerService(Packaging.class, mock(Packaging.class), null);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("name", "test-vault-builder");
+        config.put("type", "jcrvlt"); 
+
+        VaultDistributionPackageBuilderFactory factory = new VaultDistributionPackageBuilderFactory();
+        MockOsgi.injectServices(factory, context);
+        MockOsgi.activate(factory, context, config);
+
+        ServiceReference<Runnable> ref = context.getServiceReference(Runnable.class);
+        assertNotNull("Cleanup task should be registered", ref);
+
+        assertEquals("org-apache-sling-distribution", ref.getProperty(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL));
+    }
+}


### PR DESCRIPTION
Issue: [SLING-11026](https://issues.apache.org/jira/browse/SLING-11026)

Related PR:
https://github.com/apache/sling-org-apache-sling-distribution-journal/pull/179


This PR configures [DistributionPackageBuilderFactory](https://github.com/bkkothari2255/sling-org-apache-sling-distribution-core/blob/49b4b6aeffd629ad3690416094383e68a9775d04/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java#L189) and [VaultDistributionPackageBuilderFactory](https://github.com/bkkothari2255/sling-org-apache-sling-distribution-core/blob/49b4b6aeffd629ad3690416094383e68a9775d04/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java#L276) to use the dedicated thread pool `org-apache-sling-distribution` for their scheduled cleanup tasks, instead of the default `content-distribution` pool.

This ensures proper isolation of distribution cleanup operations.

**Changes:**
- Updated builder factories to register the cleanup task with the correct `scheduler.threadPool` property.
- Added unit tests to verify the configuration.


**Verification:**
- Unit tests pass.
- Standard build verification passed.