### PR TITLE
SLING-13127: Remove obsolete ImportOptions.setPatchKeepInRepo call

### DIFF
--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VltUtils.java
@@ -250,7 +250,6 @@ public class VltUtils {
             opts.setImportMode(ImportMode.UPDATE);
         }
 
-        opts.setPatchKeepInRepo(false);
 
         if (importSettings.getAutosaveThreshold() >= 0) {
             opts.setAutoSaveThreshold(importSettings.getAutosaveThreshold());


### PR DESCRIPTION
Issue: SLING-13127

In Apache Jackrabbit FileVault version 4.2.0, the ability to patch files in the filesystem was completely removed as part of JCRVLT-825. 

Because the setPatchKeepInRepo(boolean) method no longer exists in the newer FileVault API, leaving this method call in Sling will break the build (Method Not Found) when Sling attempts to upgrade its FileVault dependency. 

Removing this now removes technical debt for a clean FileVault upgrade.