### PR TITLE
SLING-11026: Use dedicated threadpool for ResourceDistributionPackageCleanup

### DIFF
--- a/src/main/java/org/apache/sling/distribution/component/impl/DistributionComponentConstants.java
+++ b/src/main/java/org/apache/sling/distribution/component/impl/DistributionComponentConstants.java
@@ -39,4 +39,9 @@ public class DistributionComponentConstants {
      */
     public static final String PN_NAME = "name";
 
+    /**
+     * Common thread pool name for distribution components.
+     */
+    public static final String THREAD_POOL_NAME = "org-apache-sling-distribution";
+
 }

--- a/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageCleanup.java
+++ b/src/main/java/org/apache/sling/distribution/packaging/impl/ResourceDistributionPackageCleanup.java
@@ -32,7 +32,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This runnable removes unreferenced {@link ResourceDistributionPackage} packages.
- * It is meant to be run periodically. See SLING-6503.
+ * It is meant to be run periodically on a dedicated thread pool.
+ * See SLING-6503 and SLING-11026.
  */
 public class ResourceDistributionPackageCleanup implements Runnable {
 

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -27,6 +27,7 @@ import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.distribution.DistributionRequest;
 import org.apache.sling.distribution.common.DistributionException;
+import org.apache.sling.distribution.component.impl.DistributionComponentConstants;
 import org.apache.sling.distribution.component.impl.SettingsUtils;
 import org.apache.sling.distribution.monitor.impl.MonitoringDistributionPackageBuilder;
 import org.apache.sling.distribution.packaging.DistributionPackage;
@@ -273,6 +274,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
             props.put(Scheduler.PROPERTY_SCHEDULER_CONCURRENT, false);
             props.put(Scheduler.PROPERTY_SCHEDULER_PERIOD, cleanupDelay);
             props.put(Scheduler.PROPERTY_SCHEDULER_RUN_ON, Scheduler.VALUE_RUN_ON_SINGLE);
+            props.put(Scheduler.PROPERTY_SCHEDULER_THREAD_POOL, DistributionComponentConstants.THREAD_POOL_NAME);
             packageCleanup = context.registerService(Runnable.class, cleanup, props);
             wrapped = resourceDistributionPackageBuilder;
         }


### PR DESCRIPTION
Issue: SLING-11026

Replaces #73 (closed per reviewer feedback).

Related PR: [#179](https://github.com/apache/sling-org-apache-sling-distribution-journal/pull/179)

Changes:
- `VaultDistributionPackageBuilderFactory`: register `ResourceDistributionPackageCleanup` 
  with dedicated thread pool `org-apache-sling-distribution`

Note: No unit tests added as the change is a single constant property value 
(per reviewer feedback on #73).