### PR TITLE
Fix digestAlgorithm NONE handling in Vault distribution package builder

### DIFF
--- a/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/DistributionPackageBuilderFactory.java
@@ -117,7 +117,7 @@ public class DistributionPackageBuilderFactory implements DistributionPackageBui
                 name = "The digest algorithm to calculate the package checksum",
                 description = "The digest algorithm to calculate the package checksum, Megabytes by default",
                 options = {
-                    @Option(label = "NONE", value = "Do not send digest"),
+                    @Option(label = "NONE", value = "NONE"),
                     @Option(label = "MD2", value = "md2"),
                     @Option(label = "MD5", value = "md5"),
                     @Option(label = "SHA-1", value = "sha1"),

--- a/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
+++ b/src/main/java/org/apache/sling/distribution/serialization/impl/vlt/VaultDistributionPackageBuilderFactory.java
@@ -161,7 +161,7 @@ public class VaultDistributionPackageBuilderFactory implements DistributionPacka
                 name = "The digest algorithm to calculate the package checksum",
                 description = "The digest algorithm to calculate the package checksum, Megabytes by default",
                 options = {
-                    @Option(label = DEFAULT_DIGEST_ALGORITHM, value = "Do not send digest"),
+                    @Option(label = DEFAULT_DIGEST_ALGORITHM, value = "NONE"),
                     @Option(label = "MD2", value = "md2"),
                     @Option(label = "MD5", value = "md5"),
                     @Option(label = "SHA-1", value = "sha1"),


### PR DESCRIPTION
When the digest option is set back to NONE through configuration/UI flows, the persisted value can become "Do not send digest" instead of the expected internal value NONE.

At runtime, package creation expects supported digest identifiers such as NONE, MD5, SHA-1, etc. If the label text is stored instead, package creation fails with:

IllegalArgumentException: Digest algorithm Do not send digest not supported in this version.

This change ensures the configuration continues to use the internal value NONE rather than the human-readable label, so reverse distribution/package creation works correctly.

Typical reproduction:

Configure the digest algorithm.
Change it to another value such as MD5.
Switch it back to NONE / "Do not send digest".
Create/export a package.
Observe failure if the label is persisted instead of NONE.